### PR TITLE
在磁盘队列中增加内存通道

### DIFF
--- a/queue/disk.go
+++ b/queue/disk.go
@@ -79,8 +79,10 @@ func NewDiskQueue(name string, dataPath string, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEveryWrite, syncEveryRead int64, syncTimeout time.Duration, writeLimit int,
 	enableMemory bool, maxMemoryLength int) BackendQueue {
-	if enableMemory && maxMemoryLength <= 0 {
-		return nil
+	if !enableMemory {
+		maxMemoryLength = 0
+	} else if enableMemory && maxMemoryLength <= 0 {
+		maxMemoryLength = 100
 	}
 	d := diskQueue{
 		name:              name,

--- a/queue/disk.go
+++ b/queue/disk.go
@@ -29,6 +29,7 @@ type diskQueue struct {
 	readFileNum  int64
 	writeFileNum int64
 	depth        int64
+	depthMemory  int64
 
 	sync.RWMutex
 
@@ -44,6 +45,8 @@ type diskQueue struct {
 	exitFlag        int32
 	needSync        bool
 	writeLimit      int // 限速 单位byte
+	enableMemory    bool
+	maxMemoryLength int64
 
 	// keeps track of the position where we have read
 	// (but not yet sent over readChan)
@@ -58,6 +61,9 @@ type diskQueue struct {
 	// exposed via ReadChan()
 	readChan chan []byte
 
+	// memory channel
+	memoryChan chan []byte
+
 	// internal channels
 	writeChan         chan []byte
 	writeResponseChan chan error
@@ -71,14 +77,21 @@ type diskQueue struct {
 // from the filesystem and starting the read ahead goroutine
 func NewDiskQueue(name string, dataPath string, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
-	syncEveryWrite, syncEveryRead int64, syncTimeout time.Duration, writeLimit int) BackendQueue {
+	syncEveryWrite, syncEveryRead int64, syncTimeout time.Duration, writeLimit int,
+	enableMemory bool, maxMemoryLength int) BackendQueue {
+	if enableMemory && maxMemoryLength <= 0 {
+		return nil
+	}
 	d := diskQueue{
 		name:              name,
 		dataPath:          dataPath,
 		maxBytesPerFile:   maxBytesPerFile,
 		minMsgSize:        minMsgSize,
 		maxMsgSize:        maxMsgSize,
+		enableMemory:      enableMemory,
+		maxMemoryLength:   int64(maxMemoryLength),
 		readChan:          make(chan []byte),
+		memoryChan:        make(chan []byte, maxMemoryLength),
 		writeChan:         make(chan []byte),
 		writeResponseChan: make(chan error),
 		emptyChan:         make(chan int),
@@ -109,7 +122,10 @@ func (d *diskQueue) Name() string {
 
 // Depth returns the depth of the queue
 func (d *diskQueue) Depth() int64 {
-	return atomic.LoadInt64(&d.depth)
+	d.RLock()
+	defer d.RUnlock()
+
+	return atomic.LoadInt64(&d.depth) + atomic.LoadInt64(&d.depthMemory)
 }
 
 // ReadChan returns the []byte channel for reading data
@@ -198,6 +214,17 @@ func (d *diskQueue) deleteAllFiles() error {
 	}
 
 	return err
+}
+
+func (d *diskQueue) deleteAllMemory() {
+	for {
+		select {
+		case <-d.memoryChan:
+		default:
+			atomic.StoreInt64(&d.depthMemory, 0)
+			return
+		}
+	}
 }
 
 func (d *diskQueue) skipToNextRWFile() error {
@@ -378,6 +405,30 @@ func (d *diskQueue) writeOne(data []byte) error {
 	}
 
 	return err
+}
+
+func (d *diskQueue) writeMemory(msg []byte) error {
+	if atomic.LoadInt64(&d.depthMemory) >= d.maxMemoryLength {
+		return errors.New("memory channel is full")
+	}
+	select {
+	case d.memoryChan <- msg:
+		atomic.AddInt64(&d.depthMemory, 1)
+		return nil
+	default:
+		return errors.New("memory channel is full")
+	}
+}
+
+func (d *diskQueue) saveToDisk() {
+	for {
+		select {
+		case msg := <-d.memoryChan:
+			d.writeOne(msg)
+		default:
+			return
+		}
+	}
 }
 
 // sync fsyncs the current writeFile and persists metadata
@@ -576,6 +627,7 @@ func (d *diskQueue) handleReadError() {
 //
 // conveniently this also means that we're asynchronously reading from the filesystem
 func (d *diskQueue) ioLoop() {
+	var origin int = FROM_NONE
 	var dataRead []byte
 	var err error
 	var count int64
@@ -603,35 +655,62 @@ func (d *diskQueue) ioLoop() {
 			}
 		}
 
-		if (d.readFileNum < d.writeFileNum) || (d.readPos < d.writePos) {
-			if d.nextReadPos == d.readPos {
-				dataRead, err = d.readOne()
-				if err != nil {
-					log.Warnf("ERROR: reading from diskqueue(%s) at %d of %s - %s",
-						d.name, d.readPos, d.fileName(d.readFileNum), err)
-					// NOTE: 根据 handleReadError() 的逻辑，只要读发生错误，就会调过当前这个文件，直接开始读下一个文件
-					d.handleReadError()
-					continue
+		if origin == FROM_NONE {
+			if (d.readFileNum < d.writeFileNum) || (d.readPos < d.writePos) {
+				if d.nextReadPos == d.readPos {
+					dataRead, err = d.readOne()
+					if err != nil {
+						log.Warnf("ERROR: reading from diskqueue(%s) at %d of %s - %s",
+							d.name, d.readPos, d.fileName(d.readFileNum), err)
+						// NOTE: 根据 handleReadError() 的逻辑，只要读发生错误，就会调过当前这个文件，直接开始读下一个文件
+						d.handleReadError()
+						continue
+					}
 				}
+				origin = FROM_DISK
+				r = d.readChan
+			} else if d.enableMemory {
+				select {
+				case dataRead = <-d.memoryChan:
+					origin = FROM_MEMORY
+					r = d.readChan
+				default:
+					r = nil
+				}
+			} else {
+				r = nil
 			}
-			r = d.readChan
 		} else {
-			r = nil
+			r = d.readChan
 		}
 
 		select {
 		// the Go channel spec dictates that nil channel operations (read or write)
 		// in a select are skipped, we set r to d.readChan only when there is data to read
 		case r <- dataRead:
-			// moveForward sets needSync flag if a file is removed
-			readCount++
-			d.moveForward()
+			switch origin {
+			case FROM_DISK:
+				// moveForward sets needSync flag if a file is removed
+				readCount++
+				d.moveForward()
+			case FROM_MEMORY:
+				atomic.AddInt64(&d.depthMemory, -1)
+			}
+			origin = FROM_NONE
 		case <-d.emptyChan:
+			if d.enableMemory {
+				d.deleteAllMemory()
+			}
 			d.emptyResponseChan <- d.deleteAllFiles()
 			count = 0
+			origin = FROM_NONE
 		case dataWrite := <-d.writeChan:
-			count++
-			d.writeResponseChan <- d.writeOne(dataWrite)
+			if d.enableMemory {
+				d.writeResponseChan <- d.writeMemory(dataWrite)
+			} else {
+				count++
+				d.writeResponseChan <- d.writeOne(dataWrite)
+			}
 		case <-syncTicker.C:
 			if count > 0 || readCount > 0 {
 				count = 0
@@ -639,12 +718,21 @@ func (d *diskQueue) ioLoop() {
 				d.needSync = true
 			}
 		case <-d.exitChan:
+			if origin == FROM_MEMORY {
+				err = d.writeOne(dataRead)
+				if err != nil {
+					log.Errorf("DISKQUEUE(%s): drop one msg - %v", d.name, err)
+				}
+			}
 			goto exit
 		}
 	}
 
 exit:
 	log.Warnf("DISKQUEUE(%s): closing ... ioLoop", d.name)
+	if d.enableMemory {
+		d.saveToDisk()
+	}
 	syncTicker.Stop()
 	d.exitSyncChan <- 1
 }

--- a/queue/disk_test.go
+++ b/queue/disk_test.go
@@ -66,6 +66,27 @@ func TestDiskQueueWithMemory(t *testing.T) {
 	dq2.Close()
 }
 
+func TestDiskQueueMemoryLength(t *testing.T) {
+	dqName := "test_disk_queue_memory_length" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dq1 := NewDiskQueue(dqName, tmpDir, 1024, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, -1).(*diskQueue)
+	assert.NotEqual(t, dq1, nil)
+	assert.Equal(t, 0, cap(dq1.memoryChan))
+	dq1.Close()
+	dq2 := NewDiskQueue(dqName, tmpDir, 1024, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, true, 0).(*diskQueue)
+	assert.NotEqual(t, dq2, nil)
+	assert.Equal(t, 100, cap(dq2.memoryChan))
+	dq2.Close()
+	dq3 := NewDiskQueue(dqName, tmpDir, 1024, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, true, 1).(*diskQueue)
+	assert.NotEqual(t, dq3, nil)
+	assert.Equal(t, 1, cap(dq3.memoryChan))
+	dq3.Close()
+}
+
 func TestDiskQueueRoll(t *testing.T) {
 	dqName := "test_disk_queue_roll" + strconv.Itoa(int(time.Now().Unix()))
 	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))

--- a/queue/disk_test.go
+++ b/queue/disk_test.go
@@ -23,7 +23,7 @@ func TestDiskQueue(t *testing.T) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewDiskQueue(dqName, tmpDir, 1024, 4, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024)
+	dq := NewDiskQueue(dqName, tmpDir, 1024, 4, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, 0)
 	assert.NotEqual(t, dq, nil)
 	assert.Equal(t, dq.Depth(), int64(0))
 
@@ -34,6 +34,36 @@ func TestDiskQueue(t *testing.T) {
 
 	msgOut := <-dq.ReadChan()
 	assert.Equal(t, msgOut, msg)
+	dq.Close()
+}
+
+func TestDiskQueueWithMemory(t *testing.T) {
+	dqName := "test_disk_queue_with_memory" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	puts := []string{"a", "b", "c", "d", "e", "f", "g"}
+	recv := []string{}
+	dq1 := NewDiskQueue(dqName, tmpDir, 1024, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, true, 7)
+	assert.NotEqual(t, dq1, nil)
+	assert.Equal(t, dq1.Depth(), int64(0))
+	for _, v := range puts {
+		err := dq1.Put([]byte(v))
+		assert.NoError(t, err)
+	}
+	dq1.Close()
+	dq2 := NewDiskQueue(dqName, tmpDir, 1024, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, true, 10)
+	assert.NotEqual(t, dq2, nil)
+	assert.Equal(t, dq2.Depth(), int64(7))
+	ch := dq2.ReadChan()
+	for range puts {
+		exp := <-ch
+		recv = append(recv, string(exp))
+	}
+	assert.Equal(t, puts, recv)
+	dq2.Close()
 }
 
 func TestDiskQueueRoll(t *testing.T) {
@@ -45,7 +75,7 @@ func TestDiskQueueRoll(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	msg := bytes.Repeat([]byte{0}, 10)
 	ml := int64(len(msg))
-	dq := NewDiskQueue(dqName, tmpDir, 9*(ml+4), int32(ml), 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024)
+	dq := NewDiskQueue(dqName, tmpDir, 9*(ml+4), int32(ml), 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, 0)
 	assert.NotEqual(t, dq, nil)
 	assert.Equal(t, dq.Depth(), int64(0))
 
@@ -57,6 +87,7 @@ func TestDiskQueueRoll(t *testing.T) {
 
 	assert.Equal(t, dq.(*diskQueue).writeFileNum, int64(1))
 	assert.Equal(t, dq.(*diskQueue).writePos, int64(0))
+	dq.Close()
 }
 
 func assertFileNotExist(t *testing.T, fn string) {
@@ -73,7 +104,7 @@ func TestDiskQueueEmpty(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	msg := bytes.Repeat([]byte{0}, 10)
-	dq := NewDiskQueue(dqName, tmpDir, 100, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024)
+	dq := NewDiskQueue(dqName, tmpDir, 100, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, 0)
 	assert.NotEqual(t, dq, nil)
 	assert.Equal(t, dq.Depth(), int64(0))
 
@@ -129,8 +160,71 @@ func TestDiskQueueEmpty(t *testing.T) {
 	assert.Equal(t, dq.(*diskQueue).readFileNum, dq.(*diskQueue).writeFileNum)
 	assert.Equal(t, dq.(*diskQueue).readPos, dq.(*diskQueue).writePos)
 	assert.Equal(t, dq.(*diskQueue).nextReadPos, dq.(*diskQueue).readPos)
+	dq.Close()
 }
 
+func TestDiskQueueEmptyWithMemory(t *testing.T) {
+	dqName := "test_disk_queue_empty_with_memory" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dq := NewDiskQueue(dqName, tmpDir, 1024, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, true, 7)
+	assert.NotEqual(t, dq, nil)
+	assert.Equal(t, dq.Depth(), int64(0))
+	puts := []string{"a", "b", "c", "d", "e", "f", "g"}
+	recv := []string{}
+	for i := 0; i < 3; i++ {
+		err := dq.Put([]byte(puts[i]))
+		assert.NoError(t, err)
+	}
+	err = dq.Empty()
+	assert.NoError(t, err)
+	for i := 3; i < len(puts); i++ {
+		err := dq.Put([]byte(puts[i]))
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	ch := dq.ReadChan()
+	for range puts[3:] {
+		exp := <-ch
+		recv = append(recv, string(exp))
+	}
+	assert.Equal(t, puts[3:], recv)
+	dq.Close()
+}
+
+func TestDiskQueueFullWithMemory(t *testing.T) {
+	dqName := "test_disk_queue_full_with_memory" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dq := NewDiskQueue(dqName, tmpDir, 1024, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, true, 5)
+	assert.NotEqual(t, dq, nil)
+	assert.Equal(t, dq.Depth(), int64(0))
+	puts := []string{"a", "b", "c", "d", "e", "f", "g"}
+	recv := []string{}
+	for i := 0; i < len(puts); {
+		err := dq.Put([]byte(puts[i]))
+		if err != nil {
+			err := dq.Empty()
+			assert.NoError(t, err)
+		} else {
+			i++
+		}
+	}
+	ch := dq.ReadChan()
+	for range puts[5:] {
+		exp := <-ch
+		recv = append(recv, string(exp))
+	}
+	assert.Equal(t, puts[5:], recv)
+	dq.Close()
+}
 func TestDiskQueueCorruption(t *testing.T) {
 	dqName := "test_disk_queue_corruption" + strconv.Itoa(int(time.Now().Unix()))
 	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
@@ -139,7 +233,7 @@ func TestDiskQueueCorruption(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	// require a non-zero message length for the corrupt (len 0) test below
-	dq := NewDiskQueue(dqName, tmpDir, 1000, 10, 1<<10, 5, 5, 2*time.Second, 10*1024*1024)
+	dq := NewDiskQueue(dqName, tmpDir, 1000, 10, 1<<10, 5, 5, 2*time.Second, 10*1024*1024, false, 0)
 
 	msg := make([]byte, 123) // 127 bytes per message, 8 (1016 bytes) messages per file
 	for i := 0; i < 25; i++ {
@@ -172,6 +266,7 @@ func TestDiskQueueCorruption(t *testing.T) {
 	dq.Put(msg)
 
 	assert.Equal(t, <-dq.ReadChan(), msg)
+	dq.Close()
 }
 
 func TestDiskQueueTorture(t *testing.T) {
@@ -183,7 +278,7 @@ func TestDiskQueueTorture(t *testing.T) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewDiskQueue(dqName, tmpDir, 262144, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024)
+	dq := NewDiskQueue(dqName, tmpDir, 262144, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, 0)
 	assert.NotEqual(t, dq, nil)
 	assert.Equal(t, dq.Depth(), int64(0))
 
@@ -224,7 +319,7 @@ func TestDiskQueueTorture(t *testing.T) {
 
 	t.Logf("restarting diskqueue")
 
-	dq = NewDiskQueue(dqName, tmpDir, 262144, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024)
+	dq = NewDiskQueue(dqName, tmpDir, 262144, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, 0)
 	assert.NotEqual(t, dq, nil)
 	assert.Equal(t, dq.Depth(), depth)
 
@@ -271,7 +366,7 @@ func BenchmarkDiskQueuePut(b *testing.B) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewDiskQueue(dqName, tmpDir, 1024768*100, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024)
+	dq := NewDiskQueue(dqName, tmpDir, 1024768*100, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, 0)
 	size := 1024
 	b.SetBytes(int64(size))
 	data := make([]byte, size)
@@ -338,7 +433,7 @@ func BenchmarkDiskQueueGet(b *testing.B) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewDiskQueue(dqName, tmpDir, 1024768, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024)
+	dq := NewDiskQueue(dqName, tmpDir, 1024768, 0, 1<<10, 2500, 2500, 2*time.Second, 10*1024*1024, false, 0)
 	for i := 0; i < b.N; i++ {
 		dq.Put([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 	}

--- a/queue/proto.go
+++ b/queue/proto.go
@@ -11,3 +11,9 @@ type BackendQueue interface {
 	Depth() int64
 	Empty() error
 }
+
+const (
+	FROM_NONE = iota
+	FROM_DISK
+	FROM_MEMORY
+)

--- a/sender/fault_tolerant_sender.go
+++ b/sender/fault_tolerant_sender.go
@@ -99,14 +99,18 @@ func NewFtSender(sender Sender, conf conf.MapConf) (*FtSender, error) {
 
 func newFtSender(innerSender Sender, runnerName string, opt *FtOption) (*FtSender, error) {
 	var lq, bq queue.BackendQueue
-	if !opt.memoryChannel {
+	if opt.saveLogPath != "" {
 		err := utils.CreateDirIfNotExist(opt.saveLogPath)
 		if err != nil {
 			return nil, err
 		}
-
-		lq = queue.NewDiskQueue("stream"+qNameSuffix, opt.saveLogPath, maxBytesPerFile, 0, maxBytesPerFile, opt.syncEvery, opt.syncEvery, time.Second*2, opt.writeLimit*mb)
-		bq = queue.NewDiskQueue("backup"+qNameSuffix, opt.saveLogPath, maxBytesPerFile, 0, maxBytesPerFile, opt.syncEvery, opt.syncEvery, time.Second*2, opt.writeLimit*mb)
+	}
+	if !opt.memoryChannel {
+		lq = queue.NewDiskQueue("stream"+qNameSuffix, opt.saveLogPath, maxBytesPerFile, 0, maxBytesPerFile, opt.syncEvery, opt.syncEvery, time.Second*2, opt.writeLimit*mb, false, 0)
+		bq = queue.NewDiskQueue("backup"+qNameSuffix, opt.saveLogPath, maxBytesPerFile, 0, maxBytesPerFile, opt.syncEvery, opt.syncEvery, time.Second*2, opt.writeLimit*mb, false, 0)
+	} else if opt.saveLogPath != "" {
+		lq = queue.NewDiskQueue("stream"+qNameSuffix, opt.saveLogPath, maxBytesPerFile, 0, maxBytesPerFile, opt.syncEvery, opt.syncEvery, time.Second*2, opt.writeLimit*mb, true, opt.memoryChannelSize)
+		bq = queue.NewDiskQueue("backup"+qNameSuffix, opt.saveLogPath, maxBytesPerFile, 0, maxBytesPerFile, opt.syncEvery, opt.syncEvery, time.Second*2, opt.writeLimit*mb, true, opt.memoryChannelSize)
 	} else {
 		lq = queue.NewMemoryQueue("steam"+memoryChanSuffix, opt.memoryChannelSize)
 		bq = queue.NewMemoryQueue("backup"+memoryChanSuffix, opt.memoryChannelSize)

--- a/sender/fault_tolerant_sender_test.go
+++ b/sender/fault_tolerant_sender_test.go
@@ -1,6 +1,8 @@
 package sender
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -59,6 +61,11 @@ func TestFtSender(t *testing.T) {
 }
 
 func TestFtMemorySender(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
 	_, pt := NewMockPandoraWithPrefix("/v2")
 	opt := &PandoraOption{
 		name:           "p",
@@ -79,6 +86,7 @@ func TestFtMemorySender(t *testing.T) {
 		t.Fatal(err)
 	}
 	mp := conf.MapConf{}
+	mp[KeyFtSaveLogPath] = tmpDir
 	mp[KeyFtMemoryChannel] = "true"
 	mp[KeyFtMemoryChannelSize] = "3"
 	mp[KeyFtStrategy] = KeyFtStrategyAlwaysSave
@@ -101,6 +109,11 @@ func TestFtMemorySender(t *testing.T) {
 }
 
 func TestFtChannelFullSender(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
 	mockP, pt := NewMockPandoraWithPrefix("/v2")
 	opt := &PandoraOption{
 		name:           "p",
@@ -124,6 +137,7 @@ func TestFtChannelFullSender(t *testing.T) {
 	mockP.PostSleep = 1
 	mockP.SetMux.Unlock()
 	mp := conf.MapConf{}
+	mp[KeyFtSaveLogPath] = tmpDir
 	mp[KeyFtMemoryChannel] = "true"
 	mp[KeyFtMemoryChannelSize] = "1"
 	mp[KeyFtStrategy] = KeyFtStrategyAlwaysSave


### PR DESCRIPTION
## Changes
   
  - [x] 在磁盘队列中增加内存通道，实现内存队列持久化功能并兼容磁盘队列。在启用内存队列时，同时设置ft_save_log_path，将使用带持久化功能的内存队列。若未设置ft_save_log_path，则维持原先的内存队列行为不变（数据不落磁盘，会有数据丢失的风险）。
 
## Reviewers

  - [ ] @wonderflow  please review

## Checklist
   
   - [x] Rebased/mergable
   - [x] Tests pass
   - [ ] CHANGELOG.md updated
   - [ ] Jira issue/task done