### PR TITLE
字段定义为string时,会丢失数据

### DIFF
--- a/reader/sql.go
+++ b/reader/sql.go
@@ -478,7 +478,7 @@ func (mr *SqlReader) exec(connectStr string) (err error) {
 							} else {
 								data[columns[i]] = &val
 							}
-						case "string":
+						default:
 							val, serr := convertString(scanArgs[i])
 							if serr != nil {
 								log.Errorf("convertString for %v (%v) error %v, ignore this key...", columns[i], scanArgs[i], serr)

--- a/reader/sql.go
+++ b/reader/sql.go
@@ -478,6 +478,13 @@ func (mr *SqlReader) exec(connectStr string) (err error) {
 							} else {
 								data[columns[i]] = &val
 							}
+						case "string":
+							val, serr := convertString(scanArgs[i])
+							if serr != nil {
+								log.Errorf("convertString for %v (%v) error %v, ignore this key...", columns[i], scanArgs[i], serr)
+							} else {
+								data[columns[i]] = &val
+							}
 						}
 					} else {
 						val, serr := convertString(scanArgs[i])


### PR DESCRIPTION
mysql reader在配置sql_schema时，将字段定义为string时由于可以在mr.schemas找到字段类型，但是switch中并没有处理string，因此数据会丢失