### PR TITLE
web优化二期的后端功能支持

### DIFF
--- a/logkit.go
+++ b/logkit.go
@@ -136,6 +136,7 @@ func main() {
 		log.Fatalf("watch path error %v", err)
 	}
 	m.RestoreWebDir()
+	m.Version = Version
 
 	stopClean := make(chan struct{}, 0)
 	defer close(stopClean)

--- a/mgr/api.md
+++ b/mgr/api.md
@@ -38,7 +38,11 @@ Content-Type: application/json
       "logpath":"/your/log/path1",
       "readDataSize": <读取数据的bytes大小>.
       "readDataCount":<读取数据条数>,
-      "elaspedtime"<总用时>,
+      "elaspedtime":<总用时>,
+      "readspeed_kb":<float>,
+      "readspeed":<float>,
+      "readspeedtrend_kb":<string>,
+      "readspeedtrend":<string>,
       "lag":{  
          "size":<lag size>,
          "files":<lag file number>,
@@ -50,12 +54,16 @@ Content-Type: application/json
       "parserStats":{  
          "errors":<error number>,
          "success":<success number>,
+         "speed":<float>,
+          "trend":<string>,
          "last_error":"error message"
       },
       "transformStats":{
           "<transformtype>":{
              "errors":<error number>,
              "success":<success number>,
+             "speed":<float>,
+              "trend":<string>,
              "last_error":"error message"
            }
       }
@@ -63,6 +71,8 @@ Content-Type: application/json
          "senderName":{
            "errors":<error number>,
            "success":<success number>,
+           "speed":<float>,
+           "trend":<string>,
            "last_error":"error message"
          }
       },
@@ -74,20 +84,31 @@ Content-Type: application/json
       "readDataSize": <读取数据的bytes大小>.
         "readDataCount":<读取数据条数>,
         "elaspedtime"<总用时>,
+         "readspeed_kb":<float>,
+          "readspeed":<float>,
+          "readspeedtrend_kb":<string>,
+          "readspeedtrend":<string>,
         "lag":{  
            "size":<lag size>,
            "files":<lag file number>,
            "ftlags":<fault torrent lags>
         },
+        "readerStats":{
+           "last_error":"error message"
+         },
         "parserStats":{  
            "errors":<error number>,
            "success":<success number>,
+           "speed":<float>,
+           "trend":<string>,
            "last_error":"error message"
         },
         "transformStats":{
             "<transformtype>":{
                "errors":<error number>,
                "success":<success number>,
+               "speed":<float>,
+                "trend":<string>,
                "last_error":"error message"
              }
         }
@@ -95,6 +116,8 @@ Content-Type: application/json
            "senderName":{
              "errors":<error number>,
              "success":<success number>,
+             "speed":<float>,
+             "trend":<string>,
              "last_error":"error message"
            }
         },
@@ -103,6 +126,16 @@ Content-Type: application/json
 }
 
 ```
+
+* "readspeed_kb": 每秒的读取流量大小 KB/s
+* "readspeed": 每秒读取记录个数 条/s
+* "readspeedtrend_kb": 流量读取速度趋势  "up" 上升,"down" 下降,"stable" 不变
+* "readspeedtrend": 记录个数速度读取趋势 "up" 上升,"down" 下降,"stable" 不变
+* "speed": 速度 条/s
+* "trend": 速度趋势 "up" 上升,"down" 下降,"stable" 不变
+* "elaspedtime": 运行时长
+
+
 
 ### 获取指定runner运行状态
 
@@ -117,26 +150,60 @@ GET /logkit/<runnerName>/status
 ```
 Content-Type: application/json
 {  
-   "name":"<runnerName>",
-   "logpath":"/your/log/path1",
-   "lag":{  
-      "size":<lag size>,
-      "files":<lag file number>,
-      "ftlags":<fault torrent lags>
-   },
-   "parserStats":{  
-      "errors":<error number>,
-      "success":<success number>,
+  "name":"runner1",
+  "logpath":"/your/log/path1",
+  "readDataSize": <读取数据的bytes大小>.
+  "readDataCount":<读取数据条数>,
+  "elaspedtime"<总用时>,
+   "readspeed_kb":<float>,
+    "readspeed":<float>,
+    "readspeedtrend_kb":<string>,
+    "readspeedtrend":<string>,
+  "lag":{  
+     "size":<lag size>,
+     "files":<lag file number>,
+     "ftlags":<fault torrent lags>
+  },
+  "readerStats":{
       "last_error":"error message"
-   },
-   "senderStats":{  
-      "errors":<error number>,
-      "success":<success number>,
-      "last_error":"error message"
-   },
-   "error":"error msg"
+  },
+  "parserStats":{  
+     "errors":<error number>,
+     "success":<success number>,
+     "speed":<float>,
+     "trend":<string>,
+     "last_error":"error message"
+  },
+  "transformStats":{
+      "<transformtype>":{
+         "errors":<error number>,
+         "success":<success number>,
+         "speed":<float>,
+          "trend":<string>,
+         "last_error":"error message"
+       }
+  }
+  "senderStats":{
+     "senderName":{
+       "errors":<error number>,
+       "success":<success number>,
+       "speed":<float>,
+        "trend":<string>,
+       "last_error":"error message"
+     }
+  },
+  "error":"error msg"
 }
 ```
+
+* "readspeed_kb": 每秒的读取流量大小 KB/s
+* "readspeed": 每秒读取记录个数 条/s
+* "readspeedtrend_kb": 流量读取速度趋势  "up" 上升,"down" 下降,"stable" 不变
+* "readspeedtrend": 记录个数速度读取趋势 "up" 上升,"down" 下降,"stable" 不变
+* "speed": 速度 条/s
+* "trend": 速度趋势 "up" 上升,"down" 下降,"stable" 不变
+* "elaspedtime": 运行时长
+
 
 ### 添加 Runner
 

--- a/mgr/api.md
+++ b/mgr/api.md
@@ -1,6 +1,22 @@
 # logkit Rest API
 
 
+## Version
+
+### 获取logkit版本号
+
+请求
+```
+GET /logkit/version
+```
+
+返回一个字符串
+
+```
+"<版本号>"
+```
+
+
 ## Runner
 
 ### 获取runner运行状态
@@ -9,12 +25,13 @@
 
 ```
 GET /logkit/status
-Content-Type: application/json
 ```
 
 返回
 
 ```
+Content-Type: application/json
+
 {  
    {  
       "name":"runner1",
@@ -26,6 +43,9 @@ Content-Type: application/json
          "size":<lag size>,
          "files":<lag file number>,
          "ftlags":<fault torrent lags>
+      },
+      "readerStats":{
+          "last_error":"error message"
       },
       "parserStats":{  
          "errors":<error number>,
@@ -90,12 +110,12 @@ Content-Type: application/json
 
 ```
 GET /logkit/<runnerName>/status 
-Content-Type: application/json
 ```
 
 返回
 
 ```
+Content-Type: application/json
 {  
    "name":"<runnerName>",
    "logpath":"/your/log/path1",

--- a/mgr/api.md
+++ b/mgr/api.md
@@ -358,6 +358,38 @@ Content-Type: application/json
 }
 ```
 
+### 重置 runner
+
+请求
+
+```
+POST /logkit/configs/<runnerName>/reset
+```
+
+返回
+
+如果请求成功, 返回HTTP状态码200:
+
+```
+{}
+```
+
+如果请求失败, 返回包含如下内容的JSON字符串（已格式化,便于阅读）:
+
+```
+{
+    "error":   "<error message string>"
+}
+```
+
+**注意**
+
+**重置runner的作用：**
+
+1. 删除runner
+2. 删除runner的meta文件夹
+3. 重新启动runner
+
 ## Reader
 
 ### 获得Reader用途说明

--- a/mgr/api.md
+++ b/mgr/api.md
@@ -266,6 +266,73 @@ Content-Type: application/json
 }
 ```
 
+### 修改 Runner
+
+请求
+
+```
+PUT /logkit/configs/<runnerName>
+Content-Type: application/json
+{
+    "name":"logkit_runner",
+    "batch_len": 1000,
+    "batch_size": 2097152,
+    "batch_interval": 300, 
+    "reader":{
+        "log_path":"/home/user/app/log/dir/",
+        "meta_path":"./metapath",
+        "donefile_retention":"7",
+        "read_from":"newest",
+        "mode":"dir",
+        "valid_file_pattern":"qiniulog-*.log" // 可不选，默认为 "*"
+    },
+     "cleaner":{
+        "delete_enable":"true",
+        "delete_interval":"10",
+        "reserve_file_number":"10",
+        "reserve_file_size":"10240"
+    },
+    "parser":{
+        "name":"json_parser",
+        "type":"json"
+    },
+    "senders":[{
+        "name":"test_sender",
+        "sender_type":"pandora",
+        "fault_tolerant":"false",
+        "pandora_ak":"your_ak",
+        "pandora_sk":"your_sk",
+        "pandora_host":"https://pipeline.qiniu.com",
+        "pandora_repo_name":"repo_test",
+        "pandora_region":"nb",
+        "pandora_schema_free":"true"
+}]
+}
+```
+
+
+返回
+
+如果请求成功, 返回HTTP状态码200:
+
+```
+{}
+```
+
+如果请求失败, 返回包含如下内容的JSON字符串（已格式化,便于阅读）:
+
+```
+{
+    "error":   "<error message string>"
+}
+```
+
+**说明**
+
+1. 修改runner时，请求体需要包含全量的配置
+2. 修改runner时，会先把原来的runner移除，然后再添加新的runner。
+
+
 ### 删除 runner
 
 请求

--- a/mgr/mgr.go
+++ b/mgr/mgr.go
@@ -49,6 +49,8 @@ type Manager struct {
 	watcherMux sync.RWMutex
 	pregistry  *parser.ParserRegistry
 	sregistry  *sender.SenderRegistry
+
+	Version string
 }
 
 func NewManager(conf ManagerConfig) (*Manager, error) {

--- a/mgr/rest.go
+++ b/mgr/rest.go
@@ -64,6 +64,9 @@ func NewRestService(mgr *Manager, router *echo.Echo) *RestService {
 	router.GET(PREFIX+"/sender/options", rs.GetSenderKeyOptions())
 	router.POST(PREFIX+"/sender/check", rs.PostSenderCheck())
 
+	//version
+	router.GET(PREFIX+"/version", rs.GetVersion())
+
 	var (
 		port     = DEFAULT_PORT
 		address  string
@@ -215,6 +218,12 @@ func (rs *RestService) DeleteConfig() echo.HandlerFunc {
 			return err
 		}
 		return os.Remove(filename)
+	}
+}
+
+func (rs *RestService) GetVersion() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		return c.String(http.StatusOK, rs.mgr.Version)
 	}
 }
 

--- a/mgr/rest_test.go
+++ b/mgr/rest_test.go
@@ -64,8 +64,9 @@ var testRestConf = `{
 
 func Test_RestGetStatus(t *testing.T) {
 	dir := "Test_Rest"
+	os.RemoveAll(dir)
 	if err := os.Mkdir(dir, 0755); err != nil {
-		log.Fatalf("Test_Run error mkdir %v %v", dir, err)
+		t.Fatalf("Test_Run error mkdir %v %v", dir, err)
 	}
 	defer os.RemoveAll(dir)
 	pwd, err := os.Getwd()
@@ -286,6 +287,7 @@ func Test_RestCRUD(t *testing.T) {
 	defer func() {
 		rs.Stop()
 		os.Remove(StatsShell)
+		os.RemoveAll(".logkitconfs")
 	}()
 	assert.Equal(t, rs.address, conf.BindHost)
 
@@ -443,4 +445,182 @@ func Test_RestCRUD(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, explists, gotlists)
 
+}
+
+func Test_RunnerReset(t *testing.T) {
+	var runnerResetConf = `{
+    "name":"test1.csv",
+    "batch_len": 1,
+    "batch_size": 200,
+    "batch_interval": 60,
+    "batch_try_times": 3,
+    "reader":{
+        "log_path":"./Test_RunnerReset/logdir",
+        "meta_path":"./Test_RunnerReset/meta_mock_csv",
+        "mode":"dir",
+        "read_from":"oldest",
+        "ignore_hidden":"true"
+    },
+    "parser":{
+        "name":         "req_csv",
+		"type":         "json"
+    },
+    "senders":[{
+		"name":           "file_sender",
+		"sender_type":    "file",
+		"file_send_path": "./Test_RunnerReset/filesenderdata"
+    }]
+}`
+
+	dir := "Test_RunnerReset"
+	if err := os.Mkdir(dir, 0755); err != nil {
+		log.Fatalf("Test_RunnerReset error mkdir %v %v", dir, err)
+	}
+	defer os.RemoveAll(dir)
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+	}
+	confdir := pwd + "/" + dir
+	logpath := dir + "/logdir"
+	metapath := dir + "/meta_mock_csv"
+	logconfs := dir + "/confs"
+	if err := os.Mkdir(logpath, 0755); err != nil {
+		log.Fatalf("Test_Run error mkdir %v %v", logpath, err)
+	}
+	if err := os.Mkdir(metapath, 0755); err != nil {
+		log.Fatalf("Test_Run error mkdir %v %v", metapath, err)
+	}
+	if err := os.Mkdir(logconfs, 0755); err != nil {
+		log.Fatalf("Test_Run error mkdir %v %v", logconfs, err)
+	}
+	log1 := `{"a":1,"b":"2"}
+	{"a":3,"b":"4"}
+	`
+	log2 := `{"a":5,"b":"6"}
+	{"a":7,"b":"8"}
+	`
+	if err := ioutil.WriteFile(filepath.Join(logpath, "log1"), []byte(log1), 0666); err != nil {
+		log.Fatalf("write log1 fail %v", err)
+	}
+	time.Sleep(time.Second)
+	if err := ioutil.WriteFile(filepath.Join(logpath, "log2"), []byte(log2), 0666); err != nil {
+		log.Fatalf("write log2 fail %v", err)
+	}
+
+	rp, err := filepath.Abs(logpath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	exp := map[string]RunnerStatus{
+		"test1.csv": {
+			Name:             "test1.csv",
+			Logpath:          rp,
+			ReadDataCount:    5,
+			ReadDataSize:     68,
+			ReadSpeedTrend:   SpeedUp,
+			ReadSpeedTrendKb: SpeedUp,
+			Lag: RunnerLag{
+				Size:  0,
+				Files: 0,
+			},
+			ParserStats: utils.StatsInfo{
+				Errors:  1,
+				Success: 4,
+				Trend:   SpeedUp,
+			},
+			TransformStats: make(map[string]utils.StatsInfo),
+			SenderStats: map[string]utils.StatsInfo{
+				"file_sender": {
+					Errors:  0,
+					Success: 4,
+					Trend:   SpeedUp,
+				},
+			},
+		},
+	}
+
+	var conf ManagerConfig
+	conf.RestDir = confdir
+	conf.BindHost = ":6346"
+	m, err := NewManager(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	confs := []string{
+		dir + "/confs",
+	}
+	err = m.Watch(confs)
+	assert.NoError(t, err)
+	rs := NewRestService(m, echo.New())
+	defer func() {
+		rs.Stop()
+		os.Remove(StatsShell)
+		os.RemoveAll(".logkitconfs")
+	}()
+
+	resp, err := http.Post("http://127.0.0.1"+rs.address+"/logkit/configs/"+"test1.csv", TESTContentApplictionJson, bytes.NewReader([]byte(runnerResetConf)))
+	assert.NoError(t, err)
+	content, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Error(string(content))
+	}
+	time.Sleep(5 * time.Second)
+
+	cmd := exec.Command("./stats")
+	cmd.Stdin = strings.NewReader("some input")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rss := make(map[string]RunnerStatus)
+	err = json.Unmarshal([]byte(out.String()), &rss)
+	assert.NoError(t, err, out.String())
+
+	v := rss["test1.csv"]
+	v.Elaspedtime = 0
+	v.ReadSpeed = 0
+	v.ReadSpeedKB = 0
+	v.ParserStats.Speed = 0
+	fs := v.SenderStats["file_sender"]
+	fs.Speed = 0
+	v.SenderStats["file_sender"] = fs
+	rss["test1.csv"] = v
+	assert.Equal(t, exp, rss, out.String())
+
+	resp, err = http.Post("http://127.0.0.1"+rs.address+"/logkit/configs/"+"test1.csv/reset", TESTContentApplictionJson, nil)
+	assert.NoError(t, err)
+	content, _ = ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Error(string(content))
+	}
+	time.Sleep(5 * time.Second)
+	out.Reset()
+	cmd = exec.Command("./stats")
+	cmd.Stdin = strings.NewReader("some input")
+	cmd.Stdout = &out
+	err = cmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rss = make(map[string]RunnerStatus)
+	err = json.Unmarshal([]byte(out.String()), &rss)
+	assert.NoError(t, err, "OUTSTRING: "+out.String())
+	rp, err = filepath.Abs(logpath)
+	if err != nil {
+		t.Error(err)
+	}
+	v = rss["test1.csv"]
+	v.Elaspedtime = 0
+	v.ReadSpeed = 0
+	v.ReadSpeedKB = 0
+	v.ParserStats.Speed = 0
+	fs = v.SenderStats["file_sender"]
+	fs.Speed = 0
+	v.SenderStats["file_sender"] = fs
+	rss["test1.csv"] = v
+	assert.Equal(t, exp, rss, out.String())
 }

--- a/mgr/rest_test.go
+++ b/mgr/rest_test.go
@@ -139,10 +139,12 @@ func Test_RestGetStatus(t *testing.T) {
 	}
 	exp := map[string]RunnerStatus{
 		"test1.csv": {
-			Name:          "test1.csv",
-			Logpath:       rp,
-			ReadDataCount: 4,
-			ReadDataSize:  29,
+			Name:             "test1.csv",
+			Logpath:          rp,
+			ReadDataCount:    4,
+			ReadDataSize:     29,
+			ReadSpeedTrend:   SpeedUp,
+			ReadSpeedTrendKb: SpeedUp,
 			Lag: RunnerLag{
 				Size:  0,
 				Files: 0,
@@ -150,12 +152,14 @@ func Test_RestGetStatus(t *testing.T) {
 			ParserStats: utils.StatsInfo{
 				Errors:  0,
 				Success: 4,
+				Trend:   SpeedUp,
 			},
 			TransformStats: make(map[string]utils.StatsInfo),
 			SenderStats: map[string]utils.StatsInfo{
 				"file_sender": {
 					Errors:  0,
 					Success: 4,
+					Trend:   SpeedUp,
 				},
 			},
 		},
@@ -163,9 +167,14 @@ func Test_RestGetStatus(t *testing.T) {
 
 	v := rss["test1.csv"]
 	v.Elaspedtime = 0
+	v.ReadSpeed = 0
+	v.ReadSpeedKB = 0
+	v.ParserStats.Speed = 0
+	fs := v.SenderStats["file_sender"]
+	fs.Speed = 0
+	v.SenderStats["file_sender"] = fs
 	rss["test1.csv"] = v
 	assert.Equal(t, exp, rss, out.String())
-
 }
 
 func Test_RestCRUD(t *testing.T) {

--- a/mgr/runner.go
+++ b/mgr/runner.go
@@ -45,6 +45,7 @@ type RunnerStatus struct {
 	ReadDataCount  int64                      `json:"readDataCount"`
 	Elaspedtime    float64                    `json:"elaspedtime"`
 	Lag            RunnerLag                  `json:"lag"`
+	ReaderStats    utils.StatsInfo            `json:"readerStats"`
 	ParserStats    utils.StatsInfo            `json:"parserStats"`
 	SenderStats    map[string]utils.StatsInfo `json:"senderStats"`
 	TransformStats map[string]utils.StatsInfo `json:"transformStats"`
@@ -594,6 +595,10 @@ func (r *LogExportRunner) Status() RunnerStatus {
 
 	for i := range r.transformers {
 		r.rs.TransformStats[r.transformers[i].Type()] = r.transformers[i].Stats()
+	}
+
+	if str, ok := r.reader.(reader.StatsReader); ok {
+		r.rs.ReaderStats = str.Status()
 	}
 
 	for i := range r.senders {

--- a/reader/bufreader_test.go
+++ b/reader/bufreader_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/qiniu/logkit/conf"
 
 	"github.com/qiniu/log"
+	"github.com/qiniu/logkit/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -222,5 +223,29 @@ func Test_BuffReaderMultiLine(t *testing.T) {
 		"test\nxtestx\n123\n":   3,
 	}
 	assert.Equal(t, exp, rest)
+	r.Close()
+}
+
+func Test_BuffReaderStats(t *testing.T) {
+	body := "Test_BuffReaderStats\n"
+	createSeqFile(1000, body)
+	defer destroySeqFile()
+	c := conf.MapConf{
+		"log_path":  dir,
+		"meta_path": metaDir,
+		"mode":      DirMode,
+		"read_from": "oldest",
+	}
+	r, err := NewFileBufReader(c)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = r.ReadLine()
+	assert.NoError(t, err)
+	str, ok := r.(StatsReader)
+	assert.Equal(t, true, ok)
+	stsx := str.Status()
+	expsts := utils.StatsInfo{}
+	assert.Equal(t, expsts, stsx)
 	r.Close()
 }

--- a/reader/elastic_test.go
+++ b/reader/elastic_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/qiniu/logkit/conf"
 
+	"github.com/qiniu/logkit/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,4 +35,7 @@ func TestElasticReader(t *testing.T) {
 	got, _, err := er.meta.ReadOffset()
 	assert.NoError(t, err)
 	assert.EqualValues(t, er.offset, got)
+
+	sts := er.Status()
+	assert.Equal(t, utils.StatsInfo{}, sts)
 }

--- a/reader/kafka_test.go
+++ b/reader/kafka_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/qiniu/logkit/conf"
 
+	"github.com/qiniu/logkit/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,4 +34,6 @@ func TestKafkaReader(t *testing.T) {
 		started:        false,
 	}
 	assert.EqualValues(t, "KafkaReader:[topic1],[group1]", er.Name())
+
+	assert.Equal(t, utils.StatsInfo{}, er.Status())
 }

--- a/reader/mongo_test.go
+++ b/reader/mongo_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/qiniu/logkit/conf"
 
+	"github.com/qiniu/logkit/utils"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -45,4 +46,6 @@ func TestMongoReader(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, er.offsetkey, got)
 	assert.EqualValues(t, int64(123), gotoffset)
+
+	assert.Equal(t, utils.StatsInfo{}, er.Status())
 }

--- a/reader/multireader_test.go
+++ b/reader/multireader_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qiniu/logkit/conf"
 
 	"github.com/qiniu/log"
+	"github.com/qiniu/logkit/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,6 +50,8 @@ func Test_ActiveReader(t *testing.T) {
 	go ar.Run()
 	data := <-msgchan
 	assert.Equal(t, testContent, data.result)
+
+	assert.Equal(t, utils.StatsInfo{}, ar.Status())
 	ar.Close()
 }
 
@@ -138,6 +141,8 @@ func TestMultiReaderOneLine(t *testing.T) {
 	t.Log("mr finish listen 2 round")
 
 	assert.EqualValues(t, expresult, resultmap)
+
+	assert.Equal(t, utils.StatsInfo{}, mr.Status())
 }
 
 func TestMultiReaderMultiLine(t *testing.T) {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/qiniu/log"
 	"github.com/qiniu/logkit/conf"
+	"github.com/qiniu/logkit/utils"
 )
 
 // Reader 是一个通用的行读取reader接口
@@ -19,6 +20,13 @@ type Reader interface {
 	SetMode(mode string, v interface{}) error
 	Close() error
 	SyncMeta()
+}
+
+// StatsReader 是一个通用的带有统计接口的reader
+type StatsReader interface {
+	//Name reader名称
+	Name() string
+	Status() utils.StatsInfo
 }
 
 // FileReader reader 接口方法

--- a/reader/redis_test.go
+++ b/reader/redis_test.go
@@ -1,0 +1,20 @@
+package reader
+
+import (
+	"testing"
+
+	"github.com/qiniu/logkit/conf"
+	"github.com/qiniu/logkit/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRedisReader(t *testing.T) {
+	myconf := conf.MapConf{
+		KeyRedisDataType: "0",
+		KeyRedisKey:      "mykey",
+	}
+
+	rr, err := NewRedisReader(nil, myconf)
+	assert.NoError(t, err)
+	assert.Equal(t, utils.StatsInfo{}, rr.Status())
+}

--- a/reader/sql_test.go
+++ b/reader/sql_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/qiniu/logkit/conf"
 
+	"github.com/qiniu/logkit/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -166,6 +167,8 @@ func TestSQLReader(t *testing.T) {
 	gotSQL, err = mr.getSQL(0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, testsqls[0]+" LIMIT 123,223;", gotSQL)
+
+	assert.Equal(t, utils.StatsInfo{}, mr.Status())
 }
 
 func TestUpdateSql(t *testing.T) {

--- a/sender/fault_tolerant_sender.go
+++ b/sender/fault_tolerant_sender.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"os"
+
 	"github.com/qiniu/log"
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/queue"
@@ -166,6 +168,10 @@ func (ft *FtSender) Send(datas []Data) error {
 
 func (ft *FtSender) Stats() utils.StatsInfo {
 	return ft.stats
+}
+
+func (ft *FtSender) Reset() error {
+	return os.RemoveAll(ft.opt.saveLogPath)
 }
 
 func (ft *FtSender) Close() error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -133,10 +133,12 @@ type StatsError struct {
 }
 
 type StatsInfo struct {
-	Errors    int64  `json:"errors"`
-	Success   int64  `json:"success"`
-	LastError string `json:"last_error"`
-	Ftlag     int64  `json:"-"`
+	Errors    int64   `json:"errors"`
+	Success   int64   `json:"success"`
+	Speed     float64 `json:"speed,omitempty"`
+	Trend     string  `json:"trend,omitempty"`
+	LastError string  `json:"last_error"`
+	Ftlag     int64   `json:"-"`
 }
 
 func (se *StatsError) AddSuccess() {


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
- [x]  在首页显示logkit的版本号 （后端增加get /logkit/version接口）
- [x]  展示错误信息部分，增加reader错误 （stats接口变动）
- [x]  速率变化改为后端计算好，前端只需要展示，展示需要增加上下箭头表示速率变化（stats接口变动）
- [x]  去掉跳转至配置页面按钮，原来的 点击复制配置文件按钮 改为 复制并跳转至配置页面 （并把复制结果粘贴上去，后端支持 put接口）
- [x]  增加“重置”按钮，后端增加（post /logkit/configs/<name>/reset）效果为删除meta信息并重启。

 
## Reviewers

  - [x] @wangtuo  please review
  - [ ] @zhonghuiping   please review
    
## Checklist
   
   - [x] Rebased/mergable
   - [ ] Tests pass
   - [ ] CHANGELOG.md updated
   - [ ] Jira issue/task done