### PR TITLE
增加了忽略不符合格式的数据选项，增强了数据校验功能，增加了是否自动转换时间的选项，增加了DataSourceTag的页面显示

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -11,10 +11,14 @@
 
   - [ ] @[someone] please review
   - [ ] @[someotherone] please review
+
+## Wiki Changes
+ 
+  - options1...
+  - options2...
     
 ## Checklist
    
    - [ ] Rebased/mergable
    - [ ] Tests pass
-   - [ ] CHANGELOG.md updated
-   - [ ] Jira issue/task done
+   - [ ] Wiki updated

--- a/logkitweb/src/listContainer.js
+++ b/logkitweb/src/listContainer.js
@@ -240,7 +240,7 @@ class List extends Component {
         );
       },
     }, {
-      title: '重置配置',
+      title: '重置',
       dataIndex: 'reset',
       width: '5%',
       render: (text, record) => {

--- a/reader/rest_reader_models.go
+++ b/reader/rest_reader_models.go
@@ -19,6 +19,15 @@ var ModeUsages = []utils.KeyValue{
 	{ModeRedis, "从 redis 读取"},
 }
 
+var (
+	OptionDataSourceTag = utils.Option{
+		KeyName:      KeyDataSourceTag,
+		ChooseOnly:   false,
+		Default:      "",
+		DefaultNoUse: false,
+		Description:  "具体的数据文件路径来源标签(datasource_tag)",
+	}
+)
 var ModeKeyOptions = map[string][]utils.Option{
 	ModeDir: {
 		{
@@ -75,6 +84,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			DefaultNoUse: false,
 			Description:  "编码方式(encoding)",
 		},
+		OptionDataSourceTag,
 		{
 			KeyName:      KeyReadIOLimit,
 			ChooseOnly:   false,
@@ -142,6 +152,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			ChooseOptions: []string{WhenceOldest, WhenceNewest},
 			Description:   "读取的起始位置(read_from)",
 		},
+		OptionDataSourceTag,
 		{
 			KeyName:    KeyEncoding,
 			ChooseOnly: true,
@@ -233,13 +244,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			Description:  "读取速度限制(MB/s)(readio_limit)",
 			CheckRegex:   "\\d+",
 		},
-		{
-			KeyName:      KeyDataSourceTag,
-			ChooseOnly:   false,
-			Default:      "",
-			DefaultNoUse: false,
-			Description:  "具体的数据文件路径来源标签(datasource_tag)",
-		},
+		OptionDataSourceTag,
 		{
 			KeyName:      KeyHeadPattern,
 			ChooseOnly:   false,
@@ -316,6 +321,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			DefaultNoUse: false,
 			Description:  "断点续传元数据路径(meta_path)",
 		},
+		OptionDataSourceTag,
 		{
 			KeyName:      KeyMysqlCron,
 			ChooseOnly:   false,
@@ -375,6 +381,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			DefaultNoUse: false,
 			Description:  "断点续传元数据路径(meta_path)",
 		},
+		OptionDataSourceTag,
 		{
 			KeyName:      KeyMssqlReadBatch,
 			ChooseOnly:   false,
@@ -441,6 +448,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			DefaultNoUse: false,
 			Description:  "断点续传元数据路径(meta_path)",
 		},
+		OptionDataSourceTag,
 		{
 			KeyName:      KeyESReadBatch,
 			ChooseOnly:   false,
@@ -493,6 +501,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			DefaultNoUse: false,
 			Description:  "断点续传元数据路径(meta_path)",
 		},
+		OptionDataSourceTag,
 		{
 			KeyName:      KeyMongoReadBatch,
 			ChooseOnly:   false,
@@ -552,6 +561,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			ChooseOptions: []string{WhenceOldest, WhenceNewest},
 			Description:   "读取的起始位置(read_from)",
 		},
+		OptionDataSourceTag,
 	},
 	ModeRedis: {
 		{
@@ -596,5 +606,6 @@ var ModeKeyOptions = map[string][]utils.Option{
 			Description:  "单次读取超时时间(m(分)、s(秒))(redis_timeout)",
 			CheckRegex:   "\\d+[ms]",
 		},
+		OptionDataSourceTag,
 	},
 }

--- a/sender/pandora_sender_test.go
+++ b/sender/pandora_sender_test.go
@@ -200,18 +200,20 @@ func TestPandoraSender(t *testing.T) {
 	pandora, pt := NewMockPandoraWithPrefix("/v2")
 	pandora.LetGetRepoError(true)
 	opt := &PandoraOption{
-		name:           "p",
-		repoName:       "TestPandoraSender",
-		region:         "nb",
-		endpoint:       "http://127.0.0.1:" + pt,
-		ak:             "ak",
-		sk:             "sk",
-		schema:         "ab, abc a1,d",
-		autoCreate:     "ab *s,a1 f*,ac *long,d DATE*",
-		updateInterval: time.Second,
-		reqRateLimit:   0,
-		flowRateLimit:  0,
-		gzip:           true,
+		name:               "p",
+		repoName:           "TestPandoraSender",
+		region:             "nb",
+		endpoint:           "http://127.0.0.1:" + pt,
+		ak:                 "ak",
+		sk:                 "sk",
+		schema:             "ab, abc a1,d",
+		autoCreate:         "ab *s,a1 f*,ac *long,d DATE*",
+		updateInterval:     time.Second,
+		reqRateLimit:       0,
+		flowRateLimit:      0,
+		ignoreInvalidField: true,
+		autoConvertDate:    true,
+		gzip:               true,
 	}
 	s, err := newPandoraSender(opt)
 	if err != nil {
@@ -602,6 +604,56 @@ func TestValidSchema(t *testing.T) {
 		{
 			v:   json.Number("1.0"),
 			t:   "float",
+			exp: true,
+		},
+		{
+			v:   `{"x":1}`,
+			t:   "jsonstring",
+			exp: true,
+		},
+		{
+			v:   `{"x":1`,
+			t:   "jsonstring",
+			exp: false,
+		},
+		{
+			v:   `{"x":`,
+			t:   "string",
+			exp: true,
+		},
+		{
+			v:   "true",
+			t:   PandoraTypeBool,
+			exp: true,
+		},
+		{
+			v:   map[string]interface{}{"ahh": 123},
+			t:   PandoraTypeMap,
+			exp: true,
+		},
+		{
+			v:   []string{"12"},
+			t:   PandoraTypeMap,
+			exp: false,
+		},
+		{
+			v:   []string{"12"},
+			t:   PandoraTypeArray,
+			exp: true,
+		},
+		{
+			v:   time.Now(),
+			t:   PandoraTypeDate,
+			exp: true,
+		},
+		{
+			v:   time.Now().Format(time.RFC3339Nano),
+			t:   PandoraTypeDate,
+			exp: true,
+		},
+		{
+			v:   time.Now().Format(time.RFC3339),
+			t:   PandoraTypeDate,
 			exp: true,
 		},
 	}

--- a/sender/rest_sender_models.go
+++ b/sender/rest_sender_models.go
@@ -223,6 +223,22 @@ var ModeKeyOptions = map[string][]utils.Option{
 			DefaultNoUse:  false,
 			Description:   "数据强制类型转换(pandora_force_convert)",
 		},
+		{
+			KeyName:       KeyIgnoreInvalidField,
+			ChooseOnly:    true,
+			ChooseOptions: []string{"true", "false"},
+			Default:       "true",
+			DefaultNoUse:  false,
+			Description:   "忽略格式错误的字段(ignore_invalid_field)",
+		},
+		{
+			KeyName:       KeyPandoraAutoConvertDate,
+			ChooseOnly:    true,
+			ChooseOptions: []string{"true", "false"},
+			Default:       "true",
+			DefaultNoUse:  false,
+			Description:   "时间类型自动转换(pandora_auto_convert_date)",
+		},
 	},
 	TypeMongodbAccumulate: {
 		{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"encoding/json"
+
 	"github.com/qiniu/log"
 )
 
@@ -253,4 +255,9 @@ type OSInfo struct {
 
 func (oi *OSInfo) String() string {
 	return fmt.Sprintf("(%s; %s; %s %s)", oi.OS, oi.Core, oi.Kernel, oi.Platform)
+}
+
+func IsJSON(str string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(str), &js) == nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -155,3 +155,35 @@ func TestTuoEncodeDecode(t *testing.T) {
 		assert.EqualValues(t, ti.exp, exps)
 	}
 }
+
+func TestIsJsonString(t *testing.T) {
+	cases := []struct {
+		c   string
+		exp bool
+	}{
+		{
+			`[{"a":1}]`,
+			true,
+		},
+		{
+			`{"a":1}`,
+			true,
+		},
+		{
+			`{"a":1`,
+			false,
+		},
+		{
+			`xsx`,
+			false,
+		},
+		{
+			` `,
+			false,
+		},
+	}
+	for _, c := range cases {
+		got := IsJSON(c.c)
+		assert.Equal(t, c.exp, got)
+	}
+}


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
  - [x] 增加了忽略不符合格式的数据选项，默认开启，关闭可以节省CPU开销
  - [x] 增强了数据校验功能 
  - [x] 增加了是否自动转换时间的选项，默认开启，关闭可以节省CPU开销
  - [x] 增加了DataSourceTag的页面显示 
 
# 文档

* pandora_auto_convert_date 可选字段，默认为 true开启。会自动将用户的自动尝试转换为Pandora 的时间类型(date)，pandora的时间类型为符合RFC3339格式的字符串，若已经符合该类型，则无需开启，关闭可节省CPU开销。默认开启，会尝试将进行各种类型的格式转换，包括不同的时间格式字符串的变化，整型作为unix timestamp进行转换等等。
* ignore_invalid_field 可选字段，默认为 true开启，会进行数据格式校验，并忽略不符合格式的字段数据，默认开启，关闭可以节省CPU开销。如Pandora的类型选择了jsonstring，若字符串不是合法的json字符串，就会忽略改部分字段内容，其他字段正常上报。

## Reviewers

  - [x] @wangtuo  please review
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] CHANGELOG.md updated
   - [ ] Jira issue/task done