### PR TITLE
split 后判断返回的数组长度避免数组访问越界

### DIFF
--- a/parser/grok_parser_test.go
+++ b/parser/grok_parser_test.go
@@ -761,3 +761,16 @@ func TestTrimInvalidSpace(t *testing.T) {
 		assert.Equal(t, ti.exp, got)
 	}
 }
+
+func TestAddCustomPatterns(t *testing.T) {
+	p := &GrokParser{
+		Patterns: []string{"%{TEST_LOG_A}"},
+		CustomPatterns: `
+			DURATION
+			RESPONSE_CODE %{NUMBER:response_code}
+			RESPONSE_TIME %{DURATION:response_time}
+			TEST_LOG_A %{NUMBER:myfloat:float} %{RESPONSE_CODE} %{IPORHOST:clientip} %{RESPONSE_TIME}
+		`,
+	}
+	assert.Error(t, p.compile())
+}


### PR DESCRIPTION

## Changes
   
  - [x] split 分割字符串后判断返回的数组长度，防止数组访问越界
 
## Reviewers

  - [ ] @wonderflow  please review

## Checklist
   
   - [x] Rebased/mergable
   - [x] Tests pass
