### PR TITLE
增加对kafka reader模式下，zk的timeout配置

### DIFF
--- a/confs/kafka_json_file.conf
+++ b/confs/kafka_json_file.conf
@@ -8,7 +8,8 @@
         "kafka_topic":"test_topic1,test_topic2",
         "kafka_zookeeper":"cs19:2181,cs20:2181,cs21:2181",
         "mode": "kafka",
-        "read_from":"oldest"
+        "read_from":"oldest",
+        "kafka_zookeeper_timeout": "2"
     },
     "parser":{
         "name":"jsonParser",

--- a/reader/kafka_test.go
+++ b/reader/kafka_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"sync"
+	"time"
 	"testing"
 
 	"github.com/qiniu/logkit/conf"
@@ -26,6 +27,7 @@ func TestKafkaReader(t *testing.T) {
 		ConsumerGroup:  "group1",
 		Topics:         []string{"topic1"},
 		ZookeeperPeers: []string{"localhost:2181"},
+		ZookeeperTimeout:time.Second,
 		Whence:         "oldest",
 		readChan:       make(chan json.RawMessage),
 		errs:           make(chan error, 1000),

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -2,7 +2,7 @@ package reader
 
 import (
 	"strings"
-
+	"time"
 	"fmt"
 
 	"github.com/qiniu/log"
@@ -111,6 +111,7 @@ const (
 	KeyKafkaGroupID   = "kafka_groupid"
 	KeyKafkaTopic     = "kafka_topic"
 	KeyKafkaZookeeper = "kafka_zookeeper"
+	KeyKafkaZookeeperTimeout = "kafka_zookeeper_timeout"
 )
 
 var defaultIgnoreFileSuffix = []string{
@@ -240,8 +241,10 @@ func NewFileBufReaderWithMeta(conf conf.MapConf, meta *Meta) (reader Reader, err
 		if err != nil {
 			return nil, err
 		}
+		zkTimeout,_ := conf.GetIntOr(KeyKafkaZookeeperTimeout,1)
+
 		zookeepers, err := conf.GetStringList(KeyKafkaZookeeper)
-		reader, err = NewKafkaReader(meta, consumerGroup, topics, zookeepers, whence)
+		reader, err = NewKafkaReader(meta, consumerGroup, topics, zookeepers,time.Duration(zkTimeout) * time.Second, whence)
 	case ModeRedis:
 		reader, err = NewRedisReader(meta, conf)
 	default:


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
  - [ ] zktimeout config parameter

 
## Reviewers

  - [ ] @wangtuo  please review


## Wiki Changes
 
  - kafka_zookeeper_timeout参数增加，单位为秒。 表示consumer连接zk时的超时时间。kafka_zookeeper_timeout必须大于2* tickTime时才有效。 tickTime一般在conf/zoo.cfg中设置。参见[zk官方文档说明](https://zookeeper.apache.org/doc/r3.1.2/zookeeperStarted.html#sc_Download)
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
