### PR TITLE
兼容之前未开启 ft 的sender配置, 修复 pandora sender 失败重发时统计信息不准确的问题

### DIFF
--- a/mgr/runner.go
+++ b/mgr/runner.go
@@ -715,7 +715,7 @@ func (r *LogExportRunner) Status() RunnerStatus {
 }
 
 func calcSpeedTrend(old, new utils.StatsInfo, elaspedtime float64) (speed float64, trend string) {
-	if elaspedtime < 0.001 || new.Success == old.Success {
+	if elaspedtime < 0.001 {
 		speed = old.Speed
 	} else {
 		speed = float64(new.Success-old.Success) / elaspedtime

--- a/sender/fault_tolerant_sender.go
+++ b/sender/fault_tolerant_sender.go
@@ -81,7 +81,6 @@ type datasContext struct {
 func NewFtSender(sender Sender, conf conf.MapConf, ftSaveLogPath string) (*FtSender, error) {
 	memoryChannel, _ := conf.GetBoolOr(KeyFtMemoryChannel, false)
 	memoryChannelSize, _ := conf.GetIntOr(KeyFtMemoryChannelSize, 100)
-
 	logPath, _ := conf.GetStringOr(KeyFtSaveLogPath, ftSaveLogPath)
 	syncEvery, _ := conf.GetIntOr(KeyFtSyncEvery, DefaultFtSyncEvery)
 	writeLimit, _ := conf.GetIntOr(KeyFtWriteLimit, defaultWriteLimit)

--- a/sender/pandora_sender_test.go
+++ b/sender/pandora_sender_test.go
@@ -468,23 +468,13 @@ func TestStatsSender(t *testing.T) {
 	d := Data{}
 	d["x1"] = "hh"
 	err = s.Send([]Data{d})
-	if st, ok := err.(*utils.StatsError); ok {
-		err = st.ErrorDetail
-	}
-	if err != nil {
-		t.Error(err)
-	}
+	st, ok := err.(*utils.StatsError)
+	assert.Equal(t, true, ok)
+	assert.NoError(t, st.ErrorDetail)
+	assert.Equal(t, st.Success, int64(1))
 	if !strings.Contains(pandora.Body, "x1=hh") {
 		t.Error("not x1 find error")
 	}
-	var sd Sender = s
-	stsd, ok := sd.(StatsSender)
-	assert.Equal(t, true, ok)
-	stats := stsd.Stats()
-	expstats := utils.StatsInfo{
-		Success: 1,
-	}
-	assert.Equal(t, stats, expstats)
 }
 
 func TestConvertDate(t *testing.T) {

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -35,9 +35,10 @@ type StatsSender interface {
 
 // Sender's conf keys
 const (
-	KeySenderType = "sender_type"
-	KeyName       = "name"
-	KeyRunnerName = "runner_name"
+	KeySenderType    = "sender_type"
+	KeyFaultTolerant = "fault_tolerant"
+	KeyName          = "name"
+	KeyRunnerName    = "runner_name"
 )
 
 const UnderfinedRunnerName = "UnderfinedRunnerName"
@@ -101,9 +102,12 @@ func (r *SenderRegistry) NewSender(conf conf.MapConf, ftSaveLogPath string) (sen
 	if err != nil {
 		return
 	}
-	sender, err = NewFtSender(sender, conf, ftSaveLogPath)
-	if err != nil {
-		return
+	faultTolerant, _ := conf.GetBoolOr(KeyFaultTolerant, true)
+	if faultTolerant {
+		sender, err = NewFtSender(sender, conf, ftSaveLogPath)
+		if err != nil {
+			return
+		}
 	}
 	return sender, nil
 }


### PR DESCRIPTION

## Changes
   
  - [ ]兼容之前未开启 ft 的sender配置
  - [ ] 修复 pandora sender 失败重发时统计信息不准确的问题 
 
## Reviewers

  - [ ] @wonderflow  please review
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
