### PR TITLE
完善 logkit cluster 模块

### DIFF
--- a/mgr/cluster.go
+++ b/mgr/cluster.go
@@ -72,13 +72,13 @@ func NewCluster(cc *ClusterConfig) *Cluster {
 }
 
 func (cc *Cluster) RunRegisterLoop() error {
-	if err := Register(cc.MasterUrl, cc.myaddress, "default"); err != nil {
+	if err := Register(cc.MasterUrl, cc.myaddress, cc.mytag); err != nil {
 		return fmt.Errorf("master %v is unavaliable", cc.MasterUrl)
 	}
 	go func() {
 		for {
 			time.Sleep(15 * time.Second)
-			if err := Register(cc.MasterUrl, cc.myaddress, "default"); err != nil {
+			if err := Register(cc.MasterUrl, cc.myaddress, cc.mytag); err != nil {
 				log.Errorf("master %v is unavaliable", cc.MasterUrl)
 			}
 		}

--- a/mgr/cluster.go
+++ b/mgr/cluster.go
@@ -76,9 +76,11 @@ func (cc *Cluster) RunRegisterLoop() error {
 		return fmt.Errorf("master %v is unavaliable", cc.MasterUrl)
 	}
 	go func() {
-		time.Sleep(15 * time.Second)
-		if err := Register(cc.MasterUrl, cc.myaddress, "default"); err != nil {
-			log.Errorf("master %v is unavaliable", cc.MasterUrl)
+		for {
+			time.Sleep(15 * time.Second)
+			if err := Register(cc.MasterUrl, cc.myaddress, "default"); err != nil {
+				log.Errorf("master %v is unavaliable", cc.MasterUrl)
+			}
 		}
 	}()
 	return nil

--- a/mgr/cluster_design.md
+++ b/mgr/cluster_design.md
@@ -28,7 +28,7 @@ POST /logkit/cluster/register
 ###  Master API -- 获取slave列表
 
 ```
-GET /logkit/cluster/slaves?tag=tagvalue
+GET /logkit/cluster/slaves?tag=tagvalue&url=urlvalue
 ```
 
 返回
@@ -37,14 +37,23 @@ GET /logkit/cluster/slaves?tag=tagvalue
 [{"url":"http://10.10.0.1:1222","tag":"tag1","status":"ok","last_touch":<rfc3339 string>}]
 ```
 
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
 * status 状态有三种， ok，表示正常，30s内有联系；bad，表示1分钟内有联系；lost，表示超过1分钟无心跳
 * 可以通过tag url参数获取一类tag的列表
 
+### Master API -- 删除slave
+
+```
+DELETE /logkit/cluster/slaves?tag=tagValue&url=urlValue
+```
+
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 该操作进行后，若删除的 slave 再次发心跳注册到 master，则还会出现在 master 的 slave 列表中。
 
 ###  Master API -- 获取runner状态列表
 
 ```
-GET /logkit/cluster/status?tag=tagvalue
+GET /logkit/cluster/status?tag=tagvalue&url=urlvalue
 ```
 
 返回
@@ -71,12 +80,12 @@ Content-Type: application/json
 }
 
 ```
-如果 tag 为空，则对所有的 slave 进行操作
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
 
 ###  Master API -- 获取runner 配置文件
 
 ```
-GET /logkit/cluster/configs?tag=tagvalue
+GET /logkit/cluster/configs?tag=tagvalue&url=urlvalue
 ```
 
 返回
@@ -102,7 +111,7 @@ Content-Type: application/json
 }
 
 ```
-如果 tag 为空，则对所有的 slave 进行操作
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
 
 ### Slave API -- 注册（修改）标签
 
@@ -115,175 +124,185 @@ POST /logkit/cluster/tag
 
 修改slave 的标签，slave向master发送心跳时通过register接口顺便做修改
 
-### Master API -- 为 tag=tagValue 的 Slave 添加 runner
+### Master API -- 为 Slave 添加 runner
 
 ```
-POST /logkit/cluster/configs/<runnerName>?tag=tagValue
+POST /logkit/cluster/configs/<runnerName>?tag=tagValue&url=urlValue
 {
     "name": "runner-xxx",
     ....
     以下略过，request body 为 logkit runner 的配置文件
 }
 ```
-
-如果 tag 为空，则对所有的 slave 进行操作
-
-如果有错误，response body 中为错误信息:
-
-若返回码为 400, 则错误信息格式为:
-```
-{"error": <error message>}
-```
-若返回码为 503, 则错误信息格式为:
-```
-{
-    <slave_url>: {
-        "url": <slave_url>,
-        "tag": <slave_tag>,
-        "mgrType": <操作类型('add', 'update', 'delete', 'start', 'stop', 'reset')>,
-        "error": <错误信息>
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 如果有错误，response body 中为错误信息:
+    * 若返回码为 400, 则错误信息格式为:
+    ```
+    {"error": <error message>}
+    ```
+    * 若返回码为 503, 则错误信息格式为:
+    ```
+    {
+        <slave_url>: {
+            "url": <slave_url>,
+            "tag": <slave_tag>,
+            "mgrType": <进行的操作(比如 add runner <runnerName>, change tag等)>,
+            "error": <错误信息>
+        }
+        ...
     }
-    ...
-}
-```
+    ```
 
-### Master API -- 为 tag=tagValue 的 Slave 更新 runner
+### Master API -- 为 Slave 更新 runner
 
 ```
-PUT /logkit/cluster/configs/<runnerName>?tag=tagValue
+PUT /logkit/cluster/configs/<runnerName>?tag=tagValue&url=urlValue
 {
     "name": "runner-xxx",
     ....
     以下忽略，request body 为 logkit runner 的配置文件
 }
 ```
-
-如果 tag 为空，则对所有的 slave 进行操作
-
-如果有错误，response body 中为错误信息:
-
-若返回码为 400, 则错误信息格式为:
-```
-{"error": <error message>}
-```
-若返回码为 503, 则错误信息格式为:
-```
-{
-    <slave_url>: {
-        "url": <slave_url>,
-        "tag": <slave_tag>,
-        "mgrType": <操作类型('add', 'update', 'delete', 'start', 'stop', 'reset')>,
-        "error": <错误信息>
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 如果有错误，response body 中为错误信息:
+    * 若返回码为 400, 则错误信息格式为:
+    ```
+    {"error": <error message>}
+    ```
+    * 若返回码为 503, 则错误信息格式为:
+    ```
+    {
+        <slave_url>: {
+            "url": <slave_url>,
+            "tag": <slave_tag>,
+            "mgrType": <进行的操作(比如 add runner <runnerName>, change tag等)>,
+            "error": <错误信息>
+        }
+        ...
     }
-    ...
+    ```
+
+### Master API -- 为 Slave 删除 runner
+
+```
+DELETE /logkit/cluster/configs/<runnerName>?tag=tagValue&url=urlValue
+```
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 如果有错误，response body 中为错误信息:
+    * 若返回码为 400, 则错误信息格式为:
+    ```
+    {"error": <error message>}
+    ```
+    * 若返回码为 503, 则错误信息格式为:
+    ```
+    {
+        <slave_url>: {
+            "url": <slave_url>,
+            "tag": <slave_tag>,
+            "mgrType": <进行的操作(比如 add runner <runnerName>, change tag等)>,
+            "error": <错误信息>
+        }
+        ...
+    }
+    ```
+
+### Master API -- 为 Slave 停止 runner
+
+```
+POST /logkit/cluster/configs/<runnerName>/stop?tag=tagValue&url=urlValue
+```
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 如果有错误，response body 中为错误信息:
+    * 若返回码为 400, 则错误信息格式为:
+    ```
+    {"error": <error message>}
+    ```
+    * 若返回码为 503, 则错误信息格式为:
+    ```
+    {
+        <slave_url>: {
+            "url": <slave_url>,
+            "tag": <slave_tag>,
+            "mgrType": <进行的操作(比如 add runner <runnerName>, change tag等)>,
+            "error": <错误信息>
+        }
+        ...
+    }
+    ```
+
+### Master API -- 为 Slave 启动 runner
+
+```
+POST /logkit/cluster/configs/<runnerName>/start?tag=tagValue&url=urlValue
+```
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 如果有错误，response body 中为错误信息:
+    * 若返回码为 400, 则错误信息格式为:
+    ```
+    {"error": <error message>}
+    ```
+    * 若返回码为 503, 则错误信息格式为:
+    ```
+    {
+        <slave_url>: {
+            "url": <slave_url>,
+            "tag": <slave_tag>,
+            "mgrType": <进行的操作(比如 add runner <runnerName>, change tag等)>,
+            "error": <错误信息>
+        }
+        ...
+    }
+    ```
+
+### Master API -- 为 Slave 重置 runner
+
+```
+POST /logkit/cluster/configs/<runnerName>/reset?tag=tagValue&url=urlValue
+```
+
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 如果有错误，response body 中为错误信息:
+    * 若返回码为 400, 则错误信息格式为:
+    ```
+    {"error": <error message>}
+    ```
+    * 若返回码为 503, 则错误信息格式为:
+    ```
+    {
+        <slave_url>: {
+            "url": <slave_url>,
+            "tag": <slave_tag>,
+            "mgrType": <进行的操作(比如 add runner <runnerName>, change tag等)>,
+            "error": <错误信息>
+        }
+        ...
+    }
+    ```
+
+### Master API -- 为 Slave 设置 tag
+
+```
+POST logkit/cluster/slaves/tag?tag=tagValue&url=urlValue
+{
+  "tag":"first"
 }
 ```
 
-### Master API -- 为 tag=tagValue 的 Slave 删除 runner
-
-```
-DELETE /logkit/cluster/configs/<runnerName>?tag=tagValue
-```
-
-如果 tag 为空，则对所有的 slave 进行操作
-
-如果有错误，response body 中为错误信息:
-
-若返回码为 400, 则错误信息格式为:
-```
-{"error": <error message>}
-```
-若返回码为 503, 则错误信息格式为:
-```
-{
-    <slave_url>: {
-        "url": <slave_url>,
-        "tag": <slave_tag>,
-        "mgrType": <操作类型('add', 'update', 'delete', 'start', 'stop', 'reset')>,
-        "error": <错误信息>
+* 参数`tag`和`url`非空时将作为被操作`slave`的过滤条件，即上述操作只对满足对应条件的`slave`有效。
+* 如果有错误，response body 中为错误信息:
+    * 若返回码为 400, 则错误信息格式为:
+    ```
+    {"error": <error message>}
+    ```
+    * 若返回码为 503, 则错误信息格式为:
+    ```
+    {
+        <slave_url>: {
+            "url": <slave_url>,
+            "tag": <slave_tag>,
+            "mgrType": <进行的操作(比如 add runner <runnerName>, change tag等)>,
+            "error": <错误信息>
+        }
+        ...
     }
-    ...
-}
-```
-
-### Master API -- 为 tag=tagValue 的 Slave 停止 runner
-
-```
-POST /logkit/cluster/configs/<runnerName>/stop?tag=tagValue
-```
-
-如果 tag 为空，则对所有的 slave 进行操作
-
-如果有错误，response body 中为错误信息:
-
-若返回码为 400, 则错误信息格式为:
-```
-{"error": <error message>}
-```
-若返回码为 503, 则错误信息格式为:
-```
-{
-    <slave_url>: {
-        "url": <slave_url>,
-        "tag": <slave_tag>,
-        "mgrType": <操作类型('add', 'update', 'delete', 'start', 'stop', 'reset')>,
-        "error": <错误信息>
-    }
-    ...
-}
-```
-
-### Master API -- 为 tag=tagValue 的 Slave 启动 runner
-
-```
-POST /logkit/cluster/configs/<runnerName>/start?tag=tagValue
-```
-
-如果 tag 为空，则对所有的 slave 进行操作
-
-如果有错误，response body 中为错误信息:
-
-若返回码为 400, 则错误信息格式为:
-```
-{"error": <error message>}
-```
-若返回码为 503, 则错误信息格式为:
-```
-{
-    <slave_url>: {
-        "url": <slave_url>,
-        "tag": <slave_tag>,
-        "mgrType": <操作类型('add', 'update', 'delete', 'start', 'stop', 'reset')>,
-        "error": <错误信息>
-    }
-    ...
-}
-```
-
-### Master API -- 为 tag=tagValue 的 Slave 重置 runner
-
-```
-POST /logkit/cluster/configs/<runnerName>/reset?tag=tagValue
-```
-
-如果 tag 为空，则对所有的 slave 进行操作
-
-如果有错误，response body 中为错误信息:
-
-若返回码为 400, 则 response body 为一条错误信息
-若返回码为 400, 则错误信息格式为:
-```
-{"error": <error message>}
-```
-若返回码为 503, 则错误信息格式为:
-```
-{
-    <slave_url>: {
-        "url": <slave_url>,
-        "tag": <slave_tag>,
-        "mgrType": <操作类型('add', 'update', 'delete', 'start', 'stop', 'reset')>,
-        "error": <错误信息>
-    }
-    ...
-}
-```
+    ```

--- a/mgr/mgr.go
+++ b/mgr/mgr.go
@@ -400,7 +400,7 @@ func (m *Manager) addWatchers(confsPath []string) (err error) {
 			continue
 		}
 		if len(paths) <= 0 {
-			log.Warnf("confPath Config %v can not find any real conf dir", dir)
+			log.Debugf("confPath Config %v can not find any real conf dir", dir)
 		}
 		for _, path := range paths {
 			m.watcherMux.RLock()

--- a/mgr/rest.go
+++ b/mgr/rest.go
@@ -96,6 +96,8 @@ func NewRestService(mgr *Manager, router *echo.Echo) *RestService {
 	router.POST(PREFIX+"/cluster/register", rs.PostRegister())
 	router.POST(PREFIX+"/cluster/tag", rs.PostTag())
 	router.GET(PREFIX+"/cluster/slaves", rs.Slaves())
+	router.DELETE(PREFIX+"/cluster/slaves", rs.DeleteSlaves())
+	router.POST(PREFIX+"/cluster/slaves/tag", rs.PostSlaveTag())
 	router.GET(PREFIX+"/cluster/status", rs.ClusterStatus())
 	router.GET(PREFIX+"/cluster/configs", rs.GetClusterConfigs())
 	router.POST(PREFIX+"/cluster/configs/:name", rs.PostClusterConfig())


### PR DESCRIPTION
## Changes
   
  - [ ] 将检测默认配置文件夹存不存在的日志置为 debug 级别
  - [ ] 修复 logkit 向 master 发心跳只发一遍的 bug
  - [ ] 修复 slave 向 master 发心跳注册时一直发送默认 tag 的 bug
  - [ ] 添加了两个 master 的 API, 并让已有的 API 支持用 url 过滤 slave

## Reviewers

  - [ ] @wonderflow  please review

## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
