### PR TITLE
add Socket reader

### DIFF
--- a/mgr/metric_runner.go
+++ b/mgr/metric_runner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/qiniu/log"
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/metric"

--- a/mgr/metric_runner_test.go
+++ b/mgr/metric_runner_test.go
@@ -10,11 +10,12 @@ import (
 
 	"bufio"
 	"bytes"
+	"io"
+	"net/http"
+
 	"github.com/labstack/echo"
 	"github.com/qiniu/logkit/metric/system"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"net/http"
 )
 
 const (

--- a/parser/csv_parser.go
+++ b/parser/csv_parser.go
@@ -364,6 +364,10 @@ func (p *CsvParser) Name() string {
 	return p.name
 }
 
+func (p *CsvParser) Type() string {
+	return TypeCSV
+}
+
 func (p *CsvParser) parse(line string) (sender.Data, error) {
 	d := make(sender.Data, len(p.schema)+len(p.labels))
 	parts := strings.Split(line, p.delim)

--- a/parser/grok_parser.go
+++ b/parser/grok_parser.go
@@ -198,6 +198,10 @@ func (gp *GrokParser) Name() string {
 	return gp.name
 }
 
+func (gp *GrokParser) Type() string {
+	return TypeGrok
+}
+
 func (gp *GrokParser) Parse(lines []string) ([]sender.Data, error) {
 	datas := []sender.Data{}
 	se := &utils.StatsError{}

--- a/parser/grok_parser_test.go
+++ b/parser/grok_parser_test.go
@@ -254,7 +254,7 @@ func TestCustomInfluxdbHttpd(t *testing.T) {
 	assert.NoError(t, p.compile())
 
 	// Parse an influxdb POST request
-	m, err := p.parseLine(`[httpd] ::1 - - [14/Jun/2016:11:33:29 +0100] "POST /write?consistency=any&db=telegraf&precision=ns&rp= HTTP/1.1" 204 0 "-" "InfluxDBClient" 6f61bc44-321b-11e6-8050-000000000000 2513`)
+	m, err := p.parseLine(`[httpd] ::1 - - [14/Jun/2016:11:33:29 +0100] "POST /write?consistency=any&db=logkit&precision=ns&rp= HTTP/1.1" 204 0 "-" "InfluxDBClient" 6f61bc44-321b-11e6-8050-000000000000 2513`)
 	require.NotNil(t, m)
 	assert.NoError(t, err)
 	assert.Equal(t,
@@ -266,7 +266,7 @@ func TestCustomInfluxdbHttpd(t *testing.T) {
 			"ident":            "-",
 			"referrer":         "-",
 			"verb":             "POST",
-			"request":          "/write?consistency=any&db=telegraf&precision=ns&rp=",
+			"request":          "/write?consistency=any&db=logkit&precision=ns&rp=",
 			"response_time_us": int64(2513),
 			"agent":            "InfluxDBClient",
 			"resp_code":        "204",
@@ -276,7 +276,7 @@ func TestCustomInfluxdbHttpd(t *testing.T) {
 		m)
 
 	// Parse an influxdb GET request
-	m, err = p.parseLine(`[httpd] ::1 - - [14/Jun/2016:12:10:02 +0100] "GET /query?db=telegraf&q=SELECT+bytes%2Cresponse_time_us+FROM+logGrokParser_grok+WHERE+http_method+%3D+%27GET%27+AND+response_time_us+%3E+0+AND+time+%3E+now%28%29+-+1h HTTP/1.1" 200 578 "http://localhost:8083/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36" 8a3806f1-3220-11e6-8006-000000000000 988`)
+	m, err = p.parseLine(`[httpd] ::1 - - [14/Jun/2016:12:10:02 +0100] "GET /query?db=logkit&q=SELECT+bytes%2Cresponse_time_us+FROM+logGrokParser_grok+WHERE+http_method+%3D+%27GET%27+AND+response_time_us+%3E+0+AND+time+%3E+now%28%29+-+1h HTTP/1.1" 200 578 "http://localhost:8083/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36" 8a3806f1-3220-11e6-8006-000000000000 988`)
 	require.NotNil(t, m)
 	assert.NoError(t, err)
 	assert.Equal(t,
@@ -287,7 +287,7 @@ func TestCustomInfluxdbHttpd(t *testing.T) {
 			"http_version":     float64(1.1),
 			"ident":            "-",
 			"referrer":         "http://localhost:8083/",
-			"request":          "/query?db=telegraf&q=SELECT+bytes%2Cresponse_time_us+FROM+logGrokParser_grok+WHERE+http_method+%3D+%27GET%27+AND+response_time_us+%3E+0+AND+time+%3E+now%28%29+-+1h",
+			"request":          "/query?db=logkit&q=SELECT+bytes%2Cresponse_time_us+FROM+logGrokParser_grok+WHERE+http_method+%3D+%27GET%27+AND+response_time_us+%3E+0+AND+time+%3E+now%28%29+-+1h",
 			"response_time_us": int64(988),
 			"agent":            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36",
 			"resp_code":        "200",

--- a/parser/json_parser.go
+++ b/parser/json_parser.go
@@ -38,6 +38,10 @@ func (im *JsonParser) Name() string {
 	return im.name
 }
 
+func (im *JsonParser) Type() string {
+	return TypeJson
+}
+
 func (im *JsonParser) Parse(lines []string) ([]sender.Data, error) {
 	datas := []sender.Data{}
 	se := &utils.StatsError{}

--- a/parser/kafkarest_parser.go
+++ b/parser/kafkarest_parser.go
@@ -34,6 +34,10 @@ func (krp *KafaRestlogParser) Name() string {
 	return krp.name
 }
 
+func (krp *KafaRestlogParser) Type() string {
+	return TypeKafkaRest
+}
+
 func (krp *KafaRestlogParser) Parse(lines []string) ([]sender.Data, error) {
 	datas := []sender.Data{}
 	for _, line := range lines {

--- a/parser/nginx_parser.go
+++ b/parser/nginx_parser.go
@@ -100,6 +100,10 @@ func (p *NginxParser) Name() string {
 	return p.name
 }
 
+func (p *NginxParser) Type() string {
+	return TypeNginx
+}
+
 func (p *NginxParser) Parse(lines []string) ([]sender.Data, error) {
 	var ret []sender.Data
 	se := &utils.StatsError{}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -15,6 +15,10 @@ type LogParser interface {
 	Parse(lines []string) (datas []sender.Data, err error)
 }
 
+type ParserType interface {
+	Type() string
+}
+
 // conf 字段
 const (
 	KeyParserName = utils.GlobalKeyName
@@ -35,6 +39,7 @@ const (
 	TypeInnerMysql = "_mysql"
 	TypeJson       = "json"
 	TypeNginx      = "nginx"
+	TypeSyslog     = "syslog"
 )
 
 type Label struct {
@@ -60,6 +65,7 @@ func NewParserRegistry() *ParserRegistry {
 	ps.RegisterParser(TypeInnerMysql, NewJsonParser) //兼容
 	ps.RegisterParser(TypeJson, NewJsonParser)
 	ps.RegisterParser(TypeNginx, NewNginxParser)
+	ps.RegisterParser(TypeSyslog, NewSyslogParser)
 	return ps
 }
 

--- a/parser/qiniulog_parser.go
+++ b/parser/qiniulog_parser.go
@@ -103,6 +103,10 @@ func (p *QiniulogParser) Name() string {
 	return p.name
 }
 
+func (p *QiniulogParser) Type() string {
+	return TypeLogv1
+}
+
 func (p *QiniulogParser) GetParser(head string) (func(string) (string, string, error), error) {
 	switch head {
 	case LogHeadPrefix:

--- a/parser/rawlog_parser.go
+++ b/parser/rawlog_parser.go
@@ -38,6 +38,10 @@ func (p *RawlogParser) Name() string {
 	return p.name
 }
 
+func (p *RawlogParser) Type() string {
+	return TypeRaw
+}
+
 func (p *RawlogParser) Parse(lines []string) ([]sender.Data, error) {
 
 	se := &utils.StatsError{}

--- a/parser/rest_parser_models.go
+++ b/parser/rest_parser_models.go
@@ -9,6 +9,7 @@ var ModeUsages = []utils.KeyValue{
 	{TypeGrok, "grok 方式解析"},
 	{TypeCSV, "csv 格式日志解析"},
 	{TypeRaw, "raw 原始日志按行解析"},
+	{TypeSyslog, "syslog 日志解析"},
 	{TypeLogv1, "qiniulog 七牛日志库解析"},
 	{TypeKafkaRest, "kafkarest 日志格式解析"},
 	{TypeEmpty, "empty 通过解析清空数据"},
@@ -225,6 +226,30 @@ var ModeKeyOptions = map[string][]utils.Option{
 			Description:  "七牛日志格式顺序(qiniulog_log_headers)",
 		},
 	},
+	TypeSyslog: {
+		{
+			KeyName:      KeyParserName,
+			ChooseOnly:   false,
+			Default:      "parser",
+			DefaultNoUse: false,
+			Description:  "parser名称(name)",
+		},
+		{
+			KeyName:       KeyRFCType,
+			ChooseOnly:    true,
+			Default:       "automic",
+			ChooseOptions: []string{"automic", "rfc3164", "rfc5424", "rfc6587"},
+			DefaultNoUse:  false,
+			Description:   "syslog使用的rfc协议(syslog_rfc)",
+		},
+		{
+			KeyName:      KeyLabels,
+			ChooseOnly:   false,
+			Default:      "",
+			DefaultNoUse: false,
+			Description:  "额外的标签信息(labels)",
+		},
+	},
 	TypeKafkaRest: {
 		{
 			KeyName:      KeyParserName,
@@ -257,6 +282,7 @@ xsxs,456,asv,5.12`,
 script_filename = /data/html/
 [0x00007fec119d1720] curl_exec() /data/html/xyframework/base.go:123
 [05-May-2017 13:45:39]  [pool log] pid 4108`,
+	TypeSyslog:    `<38>Feb 05 01:02:03 abc system[253]: Listening at 0.0.0.0:3000`,
 	TypeLogv1:     `2016/10/20 17:30:21.433423 [GE2owHck-Y4IWJHS][WARN] github.com/qiniu/http/rpcutil.v1/rpc_util.go:203: E18102: The specified repo does not exist under the provided appid ~`,
 	TypeKafkaRest: `[2016-12-05 03:35:20,682] INFO 172.16.16.191 - - [05/Dec/2016:03:35:20 +0000] "POST /topics/VIP_VvBVy0tuMPPspm1A_0000000000 HTTP/1.1" 200 101640  46 (io.confluent.rest-utils.requests)`,
 	TypeEmpty:     "empty 通过解析清空数据",

--- a/parser/syslog_parser.go
+++ b/parser/syslog_parser.go
@@ -1,0 +1,268 @@
+package parser
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jeromer/syslogparser"
+	"github.com/jeromer/syslogparser/rfc3164"
+	"github.com/jeromer/syslogparser/rfc5424"
+	"github.com/qiniu/logkit/conf"
+	"github.com/qiniu/logkit/sender"
+	"github.com/qiniu/logkit/utils"
+)
+
+const (
+	detectedRFC3164 = iota
+	detectedRFC5424 = iota
+	detectedRFC6587 = iota
+	detectedLeftLog = iota
+)
+
+const (
+	KeyRFCType = "syslog_rfc"
+
+	SyslogEofLine = "!@#pandora-EOF-line#@!"
+)
+
+type LogParts map[string]interface{}
+
+type SysLogParser interface {
+	Parse() error
+	Dump() LogParts
+	Location(*time.Location)
+}
+
+type Format interface {
+	GetParser([]byte) SysLogParser
+	IsNewLine(data []byte) bool
+}
+
+type parserWrapper struct {
+	syslogparser.LogParser
+}
+
+func (w *parserWrapper) Dump() LogParts {
+	return LogParts(w.LogParser.Dump())
+}
+
+func DetectType(data []byte) (detected int) {
+	// all formats have a sapce somewhere
+	if i := bytes.IndexByte(data, ' '); i > 0 {
+		pLength := data[0:i]
+		if _, err := strconv.Atoi(string(pLength)); err == nil {
+			return detectedRFC6587
+		}
+		if len(data) < 1 || data[0] != '<' {
+			return detectedLeftLog
+		}
+		// 开头由一对尖括号组成 <12>
+		angle := bytes.IndexByte(data, '>')
+		if (angle < 0) || (angle >= i) {
+			return detectedLeftLog
+		}
+
+		//中间是0-9
+		for j := 1; j < angle; j++ {
+			if data[j] < '0' || data[j] > '9' {
+				return detectedLeftLog
+			}
+		}
+
+		// <1>1 尖括号后紧跟数字的是RFC5424
+		// 否则是 RFC3164
+		if (angle+2 == i) && (data[angle+1] >= '0') && (data[angle+1] <= '9') {
+			return detectedRFC5424
+		} else {
+			return detectedRFC3164
+		}
+	}
+	return detectedLeftLog
+}
+
+func GetFormt(format string) Format {
+	switch strings.ToLower(format) {
+	case "rfc3164":
+		return &RFC3164{}
+	case "rfc5424":
+		return &RFC5424{}
+	case "rfc6587":
+		return &RFC6587{}
+
+	}
+	return &Automatic{}
+}
+
+func NewSyslogParser(c conf.MapConf) (LogParser, error) {
+	name, _ := c.GetStringOr(KeyParserName, "")
+	labelList, _ := c.GetStringListOr(KeyLabels, []string{})
+	rfctype, _ := c.GetStringOr(KeyRFCType, "automic")
+
+	nameMap := make(map[string]struct{})
+	labels := GetLabels(labelList, nameMap)
+
+	format := GetFormt(rfctype)
+	buff := bytes.NewBuffer([]byte{})
+	return &SyslogParser{
+		name:   name,
+		labels: labels,
+		buff:   buff,
+		format: format,
+	}, nil
+}
+
+type SyslogParser struct {
+	name   string
+	labels []Label
+	buff   *bytes.Buffer
+	format Format
+}
+
+func (p *SyslogParser) Name() string {
+	return p.name
+}
+
+func (p *SyslogParser) Type() string {
+	return TypeSyslog
+}
+
+func (p *SyslogParser) Parse(lines []string) ([]sender.Data, error) {
+
+	se := &utils.StatsError{}
+	datas := []sender.Data{}
+	for idx, line := range lines {
+		d, err := p.parse(line)
+		if err != nil {
+			se.AddErrors()
+			se.ErrorIndex = append(se.ErrorIndex, idx)
+			se.ErrorDetail = err
+			se.LastError = err.Error()
+			continue
+		}
+		if len(d) < 1 {
+			continue
+		}
+		for _, label := range p.labels {
+			d[label.Name] = label.Value
+		}
+		datas = append(datas, d)
+		se.AddSuccess()
+	}
+	return datas, se
+}
+
+func (p *SyslogParser) parse(line string) (data sender.Data, err error) {
+	data = sender.Data{}
+	if p.buff.Len() > 0 {
+		if p.format.IsNewLine([]byte(line)) || line == SyslogEofLine {
+			sparser := p.format.GetParser(p.buff.Bytes())
+			err = sparser.Parse()
+			if err == nil || err.Error() == "No structured data" {
+				data = sender.Data(sparser.Dump())
+				err = nil
+			}
+			p.buff.Reset()
+		}
+	}
+	var serr error
+	if line != SyslogEofLine {
+		_, serr = p.buff.Write([]byte(line))
+	}
+	if serr != nil {
+		if err != nil {
+			err = errors.New(err.Error() + serr.Error())
+		} else {
+			err = serr
+		}
+	}
+	return
+}
+
+type RFC6587 struct{}
+
+func (f *RFC6587) GetParser(line []byte) SysLogParser {
+	return &parserWrapper{rfc5424.NewParser(line)}
+}
+
+func (f *RFC6587) IsNewLine(data []byte) bool {
+	if i := bytes.IndexByte(data, ' '); i > 0 {
+		pLength := data[0:i]
+		_, err := strconv.Atoi(string(pLength))
+		if err != nil {
+			if string(data[0:1]) == "<" {
+				// Assume this frame uses non-transparent-framing
+				return true
+			}
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+type RFC5424 struct{}
+
+func (f *RFC5424) GetParser(line []byte) SysLogParser {
+	return &parserWrapper{rfc5424.NewParser(line)}
+}
+
+func (f *RFC5424) IsNewLine(data []byte) bool {
+	// all formats have a sapce somewhere
+	if i := bytes.IndexByte(data, ' '); i > 0 {
+		if len(data) < 1 || data[0] != '<' {
+			return false
+		}
+		// 开头由一对尖括号组成 <12>
+		angle := bytes.IndexByte(data, '>')
+		if (angle < 0) || (angle >= i) {
+			return false
+		}
+		// <1>1 尖括号后紧跟数字的是RFC5424
+		// 否则是 RFC3164
+		if (angle+2 == i) && (data[angle+1] >= '0') && (data[angle+1] <= '9') {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+type RFC3164 struct{}
+
+func (f *RFC3164) GetParser(line []byte) SysLogParser {
+	return &parserWrapper{rfc3164.NewParser(line)}
+}
+
+func (f *RFC3164) IsNewLine(data []byte) bool {
+	if i := bytes.IndexByte(data, ' '); i > 1 {
+		if string(data[0:1]) != "<" || string(data[i-1:i]) != ">" {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+type Automatic struct{}
+
+func (f *Automatic) GetParser(line []byte) SysLogParser {
+	switch format := DetectType(line); format {
+	case detectedRFC3164:
+		return &parserWrapper{rfc3164.NewParser(line)}
+	case detectedRFC5424:
+		return &parserWrapper{rfc5424.NewParser(line)}
+	default:
+		return &parserWrapper{rfc3164.NewParser(line)}
+	}
+}
+
+func (f *Automatic) IsNewLine(data []byte) bool {
+	switch format := DetectType(data); format {
+	case detectedRFC6587, detectedRFC3164, detectedRFC5424:
+		return true
+	}
+	return false
+}

--- a/parser/syslog_parser_test.go
+++ b/parser/syslog_parser_test.go
@@ -1,0 +1,123 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/qiniu/logkit/conf"
+	"github.com/qiniu/logkit/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectSyslogType(t *testing.T) {
+	tests := []struct {
+		input string
+		exp   int
+	}{
+		{
+			input: "<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47- BOM'su root' failed for lonvick on /dev/pts/8",
+			exp:   detectedRFC5424,
+		},
+		{
+			input: "<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvicn on /dev/pts/8",
+			exp:   detectedRFC3164,
+		},
+		{
+			input: "<r> lonvicn on /dev/pts/8",
+			exp:   detectedLeftLog,
+		},
+	}
+	for idx, v := range tests {
+		got := DetectType([]byte(v.input))
+		assert.Equal(t, v.exp, got, fmt.Sprintf("test index: %d", idx))
+	}
+}
+
+func Test_SyslogParser(t *testing.T) {
+	c := conf.MapConf{}
+	c[KeyParserType] = "syslog"
+	c[KeyLabels] = "machine nb110"
+	p, err := NewSyslogParser(c)
+	lines := []string{
+		`<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47`,
+		`- BOM'su root' failed for lonvick on /dev/pts/8`,
+
+		`<38>Feb 05 01:02:03 abc system[253]: Listening at 0.0.0.0:3000`,
+		`<1>Feb 05 01:02:03 abc system[23]: Listening at 0.0.0.0`,
+		`:3001`,
+		`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com`,
+		`evntslog - ID47 [exampleSDID@32473 iut="3" eventSource=`,
+		`"Application" eventID="1011"][examplePriority@32473`,
+		`class="high"]`,
+		`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com`,
+		`evntslog - ID47 [exampleSDID@32473 iut="3" eventSource=`,
+		`"Application" eventID="1011"] BOMAn application`,
+		`event log entry...`,
+		`<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1`,
+		`myproc 8710 - - %% It's time to make the do-nuts.`,
+
+		`<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47`,
+		`- BOM'su root' failed for lonvick on /dev/pts/8`,
+	}
+	dts, err := p.Parse(lines)
+	if st, ok := err.(*utils.StatsError); ok {
+		err = st.ErrorDetail
+		assert.Equal(t, "", st.LastError, st.LastError)
+		assert.Equal(t, int64(0), st.Errors)
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(dts) != 6 {
+		t.Fatalf("parse lines error expect 6 lines but got %v lines", len(dts))
+	}
+	ndata, err := p.Parse([]string{SyslogEofLine})
+	if st, ok := err.(*utils.StatsError); ok {
+		err = st.ErrorDetail
+		assert.Equal(t, "", st.LastError, st.LastError)
+		assert.Equal(t, int64(0), st.Errors)
+	}
+	assert.NoError(t, err)
+	dts = append(dts, ndata...)
+	for _, dt := range dts {
+		assert.Equal(t, "nb110", dt["machine"])
+		fmt.Println(dt)
+	}
+}
+
+func TestSyslogParser5424(t *testing.T) {
+	fpas := &RFC5424{}
+	pas := fpas.GetParser([]byte("<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47\n- BOM'su root' failed for lonvick on /dev/pts/8"))
+	//assert.NoError(t, pas.Parse())
+	for k, v := range pas.Dump() {
+		fmt.Println(k, v)
+	}
+
+	fmt.Println("=====")
+	fpas = &RFC5424{}
+	pas = fpas.GetParser([]byte(`<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1
+         myproc 8710 - - %% It's time to make the do-nuts.`))
+	//assert.NoError(t, pas.Parse())
+	for k, v := range pas.Dump() {
+		fmt.Println(k, v)
+	}
+
+	fmt.Println("=====")
+	fpas = &RFC5424{}
+	pas = fpas.GetParser([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] BOMAn application
+           event log entry..`))
+	assert.NoError(t, pas.Parse())
+	for k, v := range pas.Dump() {
+		fmt.Println(k, v)
+	}
+
+	fmt.Println("=====")
+	fpas = &RFC5424{}
+	pas = fpas.GetParser([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`))
+	assert.NoError(t, pas.Parse())
+	for k, v := range pas.Dump() {
+		fmt.Println(k, v)
+	}
+
+}

--- a/reader/kafka.go
+++ b/reader/kafka.go
@@ -159,7 +159,8 @@ func (kr *KafkaReader) run() {
 			break
 		}
 	}
-	// running在退出状态改为Init
+	// running时退出 状态改为Init，以便 cron 调度下次运行
+	// stopping时推出改为 stopped，不再运行
 	defer func() {
 		atomic.CompareAndSwapInt32(&kr.status, StatusRunning, StatusInit)
 		if atomic.CompareAndSwapInt32(&kr.status, StatusStoping, StatusStopped) {

--- a/reader/mongo.go
+++ b/reader/mongo.go
@@ -203,7 +203,8 @@ func (mr *MongoReader) run() {
 			break
 		}
 	}
-	// running在退出状态改为Init
+	// running时退出 状态改为Init，以便 cron 调度下次运行
+	// stopping时推出改为 stopped，不再运行
 	defer func() {
 		atomic.CompareAndSwapInt32(&mr.status, StatusRunning, StatusInit)
 		if atomic.CompareAndSwapInt32(&mr.status, StatusStoping, StatusStopped) {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -129,6 +129,7 @@ const (
 	ModeMongo   = "mongo"
 	ModeKafka   = "kafka"
 	ModeRedis   = "redis"
+	ModeSocket  = "socket"
 )
 
 const (
@@ -247,6 +248,8 @@ func NewFileBufReaderWithMeta(conf conf.MapConf, meta *Meta, isFromWeb bool) (re
 		reader, err = NewKafkaReader(meta, consumerGroup, topics, zookeepers, time.Duration(zkTimeout)*time.Second, whence)
 	case ModeRedis:
 		reader, err = NewRedisReader(meta, conf)
+	case ModeSocket:
+		reader, err = NewSocketReader(meta, conf)
 	default:
 		err = fmt.Errorf("mode %v not supported now", mode)
 	}

--- a/reader/singlefile.go
+++ b/reader/singlefile.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"fmt"
+
 	"github.com/qiniu/log"
 )
 

--- a/reader/socket.go
+++ b/reader/socket.go
@@ -1,0 +1,354 @@
+package reader
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/qiniu/log"
+	"github.com/qiniu/logkit/conf"
+)
+
+const (
+
+	// 监听的url形式包括：
+	// socket_service_address = "tcp://:3110"
+	// socket_service_address = "tcp://127.0.0.1:http"
+	// socket_service_address = "tcp4://:3110"
+	// socket_service_address = "tcp6://:3110"
+	// socket_service_address = "tcp6://[2001:db8::1]:3110"
+	// socket_service_address = "udp://:3110"
+	// socket_service_address = "udp4://:3110"
+	// socket_service_address = "udp6://:3110"
+	// socket_service_address = "unix:///tmp/sys.sock"
+	// socket_service_address = "unixgram:///tmp/sys.sock"
+	KeySocketServiceAddress = "socket_service_address"
+
+	// 最大并发连接数
+	// 仅用于 stream sockets (e.g. TCP).
+	// 0 (default) 为无限制.
+	// socket_max_connections = 1024
+	KeySocketMaxConnections = "socket_max_connections"
+
+	// 读的超时时间
+	// 仅用于 stream sockets (e.g. TCP).
+	// 0 (default) 为没有超时
+	// socket_read_timeout = "30s"
+	KeySocketReadTimeout = "socket_read_timeout"
+
+	// Socket的Buffer大小，默认65535
+	// socket_read_buffer_size = 65535
+	KeySocketReadBufferSize = "socket_read_buffer_size"
+
+	// TCP连接的keep_alive时长
+	// 0 表示关闭keep_alive
+	// 默认5分钟
+	KeySocketKeepAlivePeriod = "socket_keep_alive_period"
+)
+
+type setReadBufferer interface {
+	SetReadBuffer(bytes int) error
+}
+
+type streamSocketReader struct {
+	Listener net.Listener
+	*SocketReader
+
+	connections    map[string]net.Conn
+	connectionsMtx sync.Mutex
+}
+
+func (ssr *streamSocketReader) listen() {
+	ssr.connections = map[string]net.Conn{}
+
+	defer func() {
+		if atomic.CompareAndSwapInt32(&ssr.status, StatusStoping, StatusStopped) {
+			close(ssr.ReadChan)
+		}
+	}()
+	for {
+		c, err := ssr.Listener.Accept()
+		if err != nil {
+			if !strings.HasSuffix(err.Error(), ": use of closed network connection") {
+				log.Error(err)
+			}
+			break
+		}
+
+		ssr.connectionsMtx.Lock()
+		if ssr.MaxConnections > 0 && len(ssr.connections) >= ssr.MaxConnections {
+			ssr.connectionsMtx.Unlock()
+			c.Close()
+			continue
+		}
+		ssr.connections[c.RemoteAddr().String()] = c
+		ssr.connectionsMtx.Unlock()
+
+		if ssr.netproto == "tcp" || ssr.netproto == "tcp4" || ssr.netproto == "tcp6" {
+			if err := ssr.setKeepAlive(c); err != nil {
+				log.Error(fmt.Errorf("unable to configure keep alive (%s): %s", ssr.ServiceAddress, err))
+			}
+		}
+
+		go ssr.read(c)
+	}
+
+	ssr.connectionsMtx.Lock()
+	for _, c := range ssr.connections {
+		c.Close()
+	}
+	ssr.connectionsMtx.Unlock()
+}
+
+func (ssr *streamSocketReader) setKeepAlive(c net.Conn) error {
+	tcpc, ok := c.(*net.TCPConn)
+	if !ok {
+		return fmt.Errorf("cannot set keep alive on a %s socket", strings.SplitN(ssr.ServiceAddress, "://", 2)[0])
+	}
+	if ssr.KeepAlivePeriod == 0 {
+		return tcpc.SetKeepAlive(false)
+	}
+	if err := tcpc.SetKeepAlive(true); err != nil {
+		return err
+	}
+	return tcpc.SetKeepAlivePeriod(ssr.KeepAlivePeriod)
+}
+
+func (ssr *streamSocketReader) removeConnection(c net.Conn) {
+	ssr.connectionsMtx.Lock()
+	delete(ssr.connections, c.RemoteAddr().String())
+	ssr.connectionsMtx.Unlock()
+}
+
+func (ssr *streamSocketReader) read(c net.Conn) {
+	defer ssr.removeConnection(c)
+	defer c.Close()
+
+	scnr := bufio.NewScanner(c)
+	for {
+		if ssr.ReadTimeout != 0 && ssr.ReadTimeout > 0 {
+			c.SetReadDeadline(time.Now().Add(ssr.ReadTimeout))
+		}
+		if !scnr.Scan() {
+			break
+		}
+		ssr.ReadChan <- string(scnr.Bytes())
+	}
+
+	if err := scnr.Err(); err != nil {
+		if err, ok := err.(net.Error); ok && err.Timeout() {
+			log.Debugf("streamSocketReader Timeout : %s", err)
+		} else if !strings.HasSuffix(err.Error(), ": use of closed network connection") {
+			log.Error(err)
+		}
+	}
+}
+
+type packetSocketReader struct {
+	PacketConn net.PacketConn
+	*SocketReader
+}
+
+func (psr *packetSocketReader) listen() {
+	buf := make([]byte, 64*1024) // 64kb - maximum size of IP packet
+
+	defer func() {
+		if atomic.CompareAndSwapInt32(&psr.status, StatusStoping, StatusStopped) {
+			close(psr.ReadChan)
+		}
+	}()
+
+	for {
+		n, _, err := psr.PacketConn.ReadFrom(buf)
+		if err != nil {
+			if !strings.HasSuffix(err.Error(), ": use of closed network connection") {
+				log.Error(err)
+			}
+			break
+		}
+		psr.ReadChan <- string(buf[:n])
+	}
+}
+
+type SocketReader struct {
+	netproto        string
+	ServiceAddress  string
+	MaxConnections  int
+	ReadBufferSize  int
+	ReadTimeout     time.Duration
+	KeepAlivePeriod time.Duration
+	status          int32
+	meta            *Meta // 记录offset的元数据
+
+	// resource need  close
+	ReadChan chan string
+	Closer   io.Closer
+}
+
+func (sr *SocketReader) Name() string {
+	return "SocketReader<" + sr.ServiceAddress + ">"
+}
+
+func (sr *SocketReader) Source() string {
+	return sr.ServiceAddress
+}
+
+func (sr *SocketReader) SetMode(mode string, v interface{}) error {
+	return errors.New("SocketReader not support readmode")
+}
+
+func (sr *SocketReader) SyncMeta() {
+	//TODO 网络监听存在丢包可能性，无法保证不丢包
+	return
+}
+
+func (sr *SocketReader) ReadLine() (data string, err error) {
+	if atomic.LoadInt32(&sr.status) == StatusInit {
+		err = sr.Start()
+		if err != nil {
+			log.Error(err)
+		}
+	}
+	timer := time.NewTimer(time.Second)
+	select {
+	case dat := <-sr.ReadChan:
+		data = string(dat)
+	case <-timer.C:
+	}
+	timer.Stop()
+	return
+}
+
+func (sr *SocketReader) Start() error {
+
+	if !atomic.CompareAndSwapInt32(&sr.status, StatusInit, StatusRunning) {
+		return errors.New("socketReader aleady started")
+	}
+
+	spl := strings.SplitN(sr.ServiceAddress, "://", 2)
+	if len(spl) != 2 {
+		return fmt.Errorf("invalid service address: %s", sr.ServiceAddress)
+	}
+	sr.netproto = spl[0]
+	if spl[0] == "unix" || spl[0] == "unixpacket" || spl[0] == "unixgram" {
+		// 通过remove来检测套接字文件是否存在
+		os.Remove(spl[1])
+	}
+
+	switch spl[0] {
+	case "tcp", "tcp4", "tcp6", "unix", "unixpacket":
+		l, err := net.Listen(spl[0], spl[1])
+		if err != nil {
+			return err
+		}
+
+		if sr.ReadBufferSize > 0 {
+			if srb, ok := l.(setReadBufferer); ok {
+				srb.SetReadBuffer(sr.ReadBufferSize)
+			} else {
+				log.Warnf("Unable to set read buffer on a %s socket", spl[0])
+			}
+		}
+
+		ssr := &streamSocketReader{
+			Listener:     l,
+			SocketReader: sr,
+		}
+
+		sr.Closer = l
+		go ssr.listen()
+	case "udp", "udp4", "udp6", "ip", "ip4", "ip6", "unixgram":
+		pc, err := net.ListenPacket(spl[0], spl[1])
+		if err != nil {
+			return err
+		}
+
+		if sr.ReadBufferSize > 0 {
+			if srb, ok := pc.(setReadBufferer); ok {
+				srb.SetReadBuffer(sr.ReadBufferSize)
+			} else {
+				log.Warnf("Unable to set read buffer on a %s socket", spl[0])
+			}
+		}
+
+		psr := &packetSocketReader{
+			PacketConn:   pc,
+			SocketReader: sr,
+		}
+
+		sr.Closer = pc
+		go psr.listen()
+	default:
+		return fmt.Errorf("unknown protocol '%s' in '%s'", spl[0], sr.ServiceAddress)
+	}
+
+	if spl[0] == "unix" || spl[0] == "unixpacket" || spl[0] == "unixgram" {
+		sr.Closer = unixCloser{path: spl[1], closer: sr.Closer}
+	}
+
+	return nil
+}
+
+func (sr *SocketReader) Close() (err error) {
+	if atomic.CompareAndSwapInt32(&sr.status, StatusRunning, StatusStoping) {
+		log.Infof("Runner[%v] Reader[%v] stopping", sr.meta.RunnerName, sr.Name())
+	} else {
+		close(sr.ReadChan)
+	}
+
+	if sr.Closer != nil {
+		err = sr.Closer.Close()
+		sr.Closer = nil
+	}
+	log.Infof("Runner[%v] Reader[%v] stopped ", sr.meta.RunnerName, sr.Name())
+	return
+}
+
+func NewSocketReader(meta *Meta, conf conf.MapConf) (*SocketReader, error) {
+	ServiceAddress, err := conf.GetString(KeySocketServiceAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	MaxConnections, _ := conf.GetIntOr(KeySocketMaxConnections, 0)
+	ReadTimeout, _ := conf.GetStringOr(KeySocketReadTimeout, "0")
+	ReadTimeoutdur, err := time.ParseDuration(ReadTimeout)
+	if err != nil {
+		return nil, err
+	}
+	ReadBufferSize, _ := conf.GetIntOr(KeySocketReadBufferSize, 65535)
+
+	KeepAlivePeriod, _ := conf.GetStringOr(KeySocketKeepAlivePeriod, "5m")
+	KeepAlivePeriodDur, err := time.ParseDuration(KeepAlivePeriod)
+	if err != nil {
+		return nil, err
+	}
+	return &SocketReader{
+		ServiceAddress:  ServiceAddress,
+		MaxConnections:  MaxConnections,
+		ReadBufferSize:  ReadBufferSize,
+		ReadTimeout:     ReadTimeoutdur,
+		KeepAlivePeriod: KeepAlivePeriodDur,
+		ReadChan:        make(chan string),
+		status:          StatusInit,
+		meta:            meta,
+	}, nil
+}
+
+type unixCloser struct {
+	path   string
+	closer io.Closer
+}
+
+func (uc unixCloser) Close() error {
+	err := uc.closer.Close()
+	os.Remove(uc.path) // ignore error
+	return err
+}

--- a/reader/socket_test.go
+++ b/reader/socket_test.go
@@ -1,0 +1,130 @@
+package reader
+
+import (
+	"log"
+	"log/syslog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/qiniu/logkit/conf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUdpSocketReader(t *testing.T) {
+	logkitConf := conf.MapConf{
+		KeyMetaPath:             metaDir,
+		KeyFileDone:             metaDir,
+		KeyRunnerName:           "TestUdpSocketReader",
+		KeyMode:                 ModeSocket,
+		KeySocketServiceAddress: "udp://:5140",
+	}
+	meta, err := NewMetaWithConf(logkitConf)
+	assert.NoError(t, err)
+	defer os.RemoveAll(metaDir)
+
+	sr, err := NewSocketReder(meta, logkitConf)
+	assert.NoError(t, err)
+	err = sr.Start()
+	assert.NoError(t, err)
+
+	sysLog, err := syslog.Dial("udp", "localhost:5140",
+		syslog.LOG_WARNING|syslog.LOG_DAEMON, "demotag")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = sysLog.Emerg("And this is a daemon emergency with demotag.")
+	assert.NoError(t, err)
+	err = sysLog.Emerg("this is OK")
+	assert.NoError(t, err)
+	time.Sleep(30 * time.Millisecond)
+	line, err := sr.ReadLine()
+	assert.NoError(t, err)
+	assert.Contains(t, line, "And this is a daemon emergency with demotag.")
+	line, err = sr.ReadLine()
+	assert.NoError(t, err)
+	assert.Contains(t, line, "this is OK")
+
+	err = sr.Close()
+	assert.NoError(t, err)
+}
+
+func TestTCPSocketReader(t *testing.T) {
+	logkitConf := conf.MapConf{
+		KeyMetaPath:             metaDir,
+		KeyFileDone:             metaDir,
+		KeyRunnerName:           "TestTCPSocketReader",
+		KeyMode:                 ModeSocket,
+		KeySocketServiceAddress: "tcp://:5141",
+	}
+	meta, err := NewMetaWithConf(logkitConf)
+	assert.NoError(t, err)
+	defer os.RemoveAll(metaDir)
+
+	sr, err := NewSocketReder(meta, logkitConf)
+	assert.NoError(t, err)
+	err = sr.Start()
+	assert.NoError(t, err)
+
+	sysLog, err := syslog.Dial("tcp", "localhost:5141",
+		syslog.LOG_WARNING|syslog.LOG_DAEMON, "demotag")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = sysLog.Emerg("And this is a daemon emergency with demotag.")
+	assert.NoError(t, err)
+	err = sysLog.Emerg("this is OK")
+	assert.NoError(t, err)
+	time.Sleep(30 * time.Millisecond)
+	line, err := sr.ReadLine()
+	assert.NoError(t, err)
+	assert.Contains(t, line, "And this is a daemon emergency with demotag.")
+	line, err = sr.ReadLine()
+	assert.NoError(t, err)
+	assert.Contains(t, line, "this is OK")
+
+	err = sr.Close()
+	assert.NoError(t, err)
+}
+
+func TestUnixSocketReader(t *testing.T) {
+	logkitConf := conf.MapConf{
+		KeyMetaPath:             metaDir,
+		KeyFileDone:             metaDir,
+		KeyRunnerName:           "TestUnixSocketReader",
+		KeyMode:                 ModeSocket,
+		KeySocketServiceAddress: "unix://./TestUnixSocketReader/log.socket",
+	}
+	meta, err := NewMetaWithConf(logkitConf)
+	assert.NoError(t, err)
+	defer os.RemoveAll(metaDir)
+
+	err = os.Mkdir("TestUnixSocketReader", 0755)
+	assert.NoError(t, err)
+	defer os.RemoveAll("TestUnixSocketReader")
+
+	sr, err := NewSocketReder(meta, logkitConf)
+	assert.NoError(t, err)
+	err = sr.Start()
+	assert.NoError(t, err)
+
+	sysLog, err := syslog.Dial("unix", "./TestUnixSocketReader/log.socket",
+		syslog.LOG_WARNING|syslog.LOG_DAEMON, "demotag")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = sysLog.Emerg("And this is unix socket test.")
+	assert.NoError(t, err)
+	err = sysLog.Emerg("this is OK")
+	assert.NoError(t, err)
+	time.Sleep(30 * time.Millisecond)
+	line, err := sr.ReadLine()
+	assert.NoError(t, err)
+	assert.Contains(t, line, "And this is unix socket test.")
+	line, err = sr.ReadLine()
+	assert.NoError(t, err)
+	assert.Contains(t, line, "this is OK")
+
+	err = sr.Close()
+	assert.NoError(t, err)
+}

--- a/reader/socket_test.go
+++ b/reader/socket_test.go
@@ -23,7 +23,7 @@ func TestUdpSocketReader(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(metaDir)
 
-	sr, err := NewSocketReder(meta, logkitConf)
+	sr, err := NewSocketReader(meta, logkitConf)
 	assert.NoError(t, err)
 	err = sr.Start()
 	assert.NoError(t, err)
@@ -61,7 +61,7 @@ func TestTCPSocketReader(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(metaDir)
 
-	sr, err := NewSocketReder(meta, logkitConf)
+	sr, err := NewSocketReader(meta, logkitConf)
 	assert.NoError(t, err)
 	err = sr.Start()
 	assert.NoError(t, err)
@@ -103,7 +103,7 @@ func TestUnixSocketReader(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll("TestUnixSocketReader")
 
-	sr, err := NewSocketReder(meta, logkitConf)
+	sr, err := NewSocketReader(meta, logkitConf)
 	assert.NoError(t, err)
 	err = sr.Start()
 	assert.NoError(t, err)

--- a/reader/sql.go
+++ b/reader/sql.go
@@ -398,7 +398,8 @@ func (mr *SqlReader) run() {
 			break
 		}
 	}
-	// running在退出状态改为Init
+	// running时退出 状态改为Init，以便 cron 调度下次运行
+	// stopping时推出改为 stopped，不再运行
 	defer func() {
 		atomic.CompareAndSwapInt32(&mr.status, StatusRunning, StatusInit)
 		if atomic.CompareAndSwapInt32(&mr.status, StatusStoping, StatusStopped) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -119,6 +119,24 @@
 			"revisionTime": "2015-10-03T19:46:02Z"
 		},
 		{
+			"checksumSHA1": "2jm5p7TKKExCRmt+McpLz0jPg2U=",
+			"path": "github.com/jeromer/syslogparser",
+			"revision": "0e4ae46ea3f08de351074b643d649d5d00661a3c",
+			"revisionTime": "2016-09-06T13:20:35Z"
+		},
+		{
+			"checksumSHA1": "Iqq1ENh1zUfKx1ikawuI7oeLko0=",
+			"path": "github.com/jeromer/syslogparser/rfc3164",
+			"revision": "0e4ae46ea3f08de351074b643d649d5d00661a3c",
+			"revisionTime": "2016-09-06T13:20:35Z"
+		},
+		{
+			"checksumSHA1": "Xfzh6sQV/bWHY6XOFnr8mJ+LfkY=",
+			"path": "github.com/jeromer/syslogparser/rfc5424",
+			"revision": "0e4ae46ea3f08de351074b643d649d5d00661a3c",
+			"revisionTime": "2016-09-06T13:20:35Z"
+		},
+		{
 			"checksumSHA1": "hz/wVE0xwQ+d8aQbX7ApZVj8Hbg=",
 			"path": "github.com/labstack/echo",
 			"revision": "70c18060bde41901b2675da5629611f6afc580bc",


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
  - [x] 读取包括tcp、udp、unixSocket在内的多种连接数据
  - [x] 解析标准的syslog日志，rfc协议为 rfc3164  rfc5424 rfc6587  不过大多数syslog都是自定义的日志格式，还是需要用grok去解析
 
## Reviewers

  - [ ] @wangtuo  please review
  - [ ] @lvheyang please review
  - [ ] @xingfeng2510 please review


## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
