### PR TITLE
metric 模块 bug 修复

### DIFF
--- a/logkitweb/src/components/metricUsages.js
+++ b/logkitweb/src/components/metricUsages.js
@@ -44,9 +44,6 @@ class Usages extends Component {
   init = () => {
     getMetricUsages().then(data => {
       const {setFieldsValue} = this.props.form;
-      data = data.sort(function(a,b){
-        return a.KeyName > b.KeyName;
-      });
       if (data.success) {
         this.setState({
           items: data,

--- a/logkitweb/src/container/createLogContainer.js
+++ b/logkitweb/src/container/createLogContainer.js
@@ -110,7 +110,8 @@ class CreateLogRunner extends Component {
           const current = this.state.current + 1;
           this.setState({current});
           let name = "runner." + moment().format("YYYYMMDDHHmmss");
-          let interval = that.refs.initConfig.getFieldValue('batch_interval')
+          let batch_interval = that.refs.initConfig.getFieldValue('batch_interval')
+          let collect_interval = that.refs.initConfig.getFieldValue('collect_interval')
           let runnerName = that.refs.initConfig.getFieldValue('name')
           if (window.isCopy && window.nodeCopy) {
             name = window.nodeCopy.name
@@ -125,7 +126,8 @@ class CreateLogRunner extends Component {
 
           let data = {
             name: runnerName != undefined ? runnerName : name,
-            batch_interval: interval != undefined ? interval : 60,
+            batch_interval: batch_interval != undefined ? batch_interval : 60,
+            collect_interval: collect_interval != undefined ? collect_interval : 3,
             ...config.getNodeData()
           }
           that.refs.initConfig.setFieldsValue({config: JSON.stringify(data, null, 2)});
@@ -133,10 +135,12 @@ class CreateLogRunner extends Component {
             that.refs.initConfig.setFieldsValue({name: name});
           }
 
-          if (interval == undefined) {
+          if (batch_interval == undefined) {
             that.refs.initConfig.setFieldsValue({batch_interval: 60});
           }
-
+          if (collect_interval == undefined) {
+            that.refs.initConfig.setFieldsValue({collect_interval: 3});
+          }
         }
       });
     }

--- a/logkitweb/src/container/createLogContainer.js
+++ b/logkitweb/src/container/createLogContainer.js
@@ -58,14 +58,16 @@ class CreateLogRunner extends Component {
     let that = this
     let isCopy = this.props.location.query.copyConfig
     if (isCopy === 'true') {
-      window.isCopy = true
+      window.isCopy = true;
       this.setState({
         isCpoyStatus: true
       })
     } else {
       window.isCopy = false
     }
-
+    if(window.nodeCopy){
+      config.delete("metric");
+    }
     getRunnerVersion().then(data => {
       if (data.success) {
         that.setState({

--- a/logkitweb/src/container/createMetricContainer.js
+++ b/logkitweb/src/container/createMetricContainer.js
@@ -123,7 +123,7 @@ class CreateMetricRunner extends Component {
           let data = {
             name: runnerName != undefined ? runnerName : name,
             batch_interval: batch_interval != undefined ? batch_interval : 60,
-            metric_interval: collect_interval != undefined ? collect_interval : 3,
+            collect_interval: collect_interval != undefined ? collect_interval : 3,
             ...config.getNodeData()
           }
           that.refs.initConfig.setFieldsValue({config: JSON.stringify(data, null, 2)});

--- a/logkitweb/src/container/createMetricContainer.js
+++ b/logkitweb/src/container/createMetricContainer.js
@@ -58,14 +58,18 @@ class CreateMetricRunner extends Component {
     let that = this
     let isCopy = this.props.location.query.copyConfig
     if (isCopy === 'true') {
-      window.isCopy = true
+      window.isCopy = true;
       this.setState({
         isCopyStatus: true
       })
     } else {
       window.isCopy = false
     }
-
+    if(window.nodeCopy){
+      config.delete("reader");
+      config.delete("parser");
+      config.delete("transforms");
+    }
     getRunnerVersion().then(data => {
       if (data.success) {
         that.setState({

--- a/logkitweb/src/store/config.js
+++ b/logkitweb/src/store/config.js
@@ -5,16 +5,21 @@ window.nodes = {}
 config.get = (type) => {
   return window.nodes[type]
 };
+
 config.set = (type, data) => {
   window.nodes[type] = data
 };
 
+config.delete = (type) => {
+  delete window.nodes[type]
+};
+
 config.getNodeData = () => {
   return window.nodes
-}
+};
 
 config.setNodeData = (data) => {
   return window.nodes = data
-}
+};
 
 export default config

--- a/metric/rest_metrics_models.go
+++ b/metric/rest_metrics_models.go
@@ -1,6 +1,10 @@
 package metric
 
-import "github.com/qiniu/logkit/utils"
+import (
+	"sort"
+
+	"github.com/qiniu/logkit/utils"
+)
 
 func GetMetricTypeKey() map[string][]utils.KeyValue {
 	typeKey := make(map[string][]utils.KeyValue)
@@ -29,6 +33,10 @@ func GetMetricUsages() []utils.Option {
 		}
 		metricOptions = append(metricOptions, option)
 	}
+	// 使传递到前端的数组有序
+	sort.Slice(metricOptions, func(i, j int) bool {
+		return metricOptions[i].KeyName < metricOptions[j].KeyName
+	})
 	return metricOptions
 }
 

--- a/metric/system/linux_sysctl_fs.go
+++ b/metric/system/linux_sysctl_fs.go
@@ -14,18 +14,75 @@ type SysctlFS struct {
 	path string
 }
 
+const (
+	TypeLinuxSysctlFs        = "linux_sysctl_fs"
+	MetricLinuxSysctlFsUsage = "linux内核信息(linux_sysctl_fs)"
+
+	KeyLinuxSysctlFsAioNr           = "aio-nr"
+	KeyLinuxSysctlFsAioMaxNr        = "aio-max-nr"
+	KeyLinuxSysctlFsDquotNr         = "dquot-nr"
+	KeyLinuxSysctlFsDquotMax        = "dquot-max"
+	KeyLinuxSysctlFsSuperNr         = "super-nr"
+	KeyLinuxSysctlFsSuperMax        = "superMax"
+	KeyLinuxSysctlFsInodeNr         = "inode-nr"
+	KeyLinuxSysctlFsInodeFreeNr     = "inode-free-nr"
+	KeyLinuxSysctlFsInodePreNr      = "inode-preshrink-nr"
+	KeyLinuxSysctlFsDentryNr        = "dentry-nr"
+	KeyLinuxSysctlFsDentryUnNr      = "dentry-unused-nr"
+	KeyLinuxSysctlFsDetryAgeLimit   = "detry-age-limit"
+	KeyLinuxSysctlFsDentryWantPages = "detry-want-pages"
+	KeyLinuxSysctlFsFileNr          = "file-nr"
+	KeyLinuxSysctlFsFileMax         = "file-max"
+)
+
+var KeySysctlFsFieldNameMap = map[string]string{
+	KeyLinuxSysctlFsAioNr:           "sysctl_fs_aio_nr",
+	KeyLinuxSysctlFsAioMaxNr:        "sysctl_fs_aio_max_nr",
+	KeyLinuxSysctlFsDquotNr:         "sysctl_fs_dquot_nr",
+	KeyLinuxSysctlFsDquotMax:        "sysctl_fs_dquot_max",
+	KeyLinuxSysctlFsSuperNr:         "sysctl_fs_super_nr",
+	KeyLinuxSysctlFsSuperMax:        "sysctl_fs_superMax",
+	KeyLinuxSysctlFsInodeNr:         "sysctl_fs_inode_nr",
+	KeyLinuxSysctlFsInodeFreeNr:     "sysctl_fs_inode_free_nr",
+	KeyLinuxSysctlFsInodePreNr:      "sysctl_fs_inode_preshrink_nr",
+	KeyLinuxSysctlFsDentryNr:        "sysctl_fs_dentry_nr",
+	KeyLinuxSysctlFsDentryUnNr:      "sysctl_fs_dentry_unused_nr",
+	KeyLinuxSysctlFsDetryAgeLimit:   "sysctl_fs_detry_age_limit",
+	KeyLinuxSysctlFsDentryWantPages: "sysctl_fs_detry_want_pages",
+	KeyLinuxSysctlFsFileNr:          "sysctl_fs_file_nr",
+	KeyLinuxSysctlFsFileMax:         "sysctl_fs_file_max",
+}
+
+var KeyLinuxSysctlFsUsage = []utils.KeyValue{
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsAioNr], "当前 aio 请求数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsAioMaxNr], "最大允许的 aio 请求"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsDquotNr], "分配的磁盘配额项及空余项"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsDquotMax], "缓存的磁盘配额的最大值"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsSuperNr], "已分配的 super block 数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsSuperMax], "系统能够分配的 super block 数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsInodeNr], "分配的 inode 数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsInodeFreeNr], "空闲的 inode 数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsInodePreNr], "inode 预缩减数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsDentryNr], "当前分配的 dentry 缓存数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsDentryUnNr], "未使用的 dentry 缓存数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsDetryAgeLimit], "dentry 缓存被创建以来的时长"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsDentryWantPages], "系统需要的页面数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsFileNr], "已分配、使用的和最大的文件句柄数"},
+	{KeySysctlFsFieldNameMap[KeyLinuxSysctlFsFileMax], "内核支持的最大file handle数量"},
+}
+
 func (_ SysctlFS) Name() string {
-	return "linux_sysctl_fs"
+	return TypeLinuxSysctlFs
 }
 
 func (_ SysctlFS) Usages() string {
-	return "linux_sysctl_fs"
+	return MetricLinuxSysctlFsUsage
 }
 
 func (_ SysctlFS) Config() map[string]interface{} {
 	config := map[string]interface{}{
 		metric.OptionString:     []utils.Option{},
-		metric.AttributesString: []utils.KeyValue{},
+		metric.AttributesString: KeyLinuxSysctlFsUsage,
 	}
 	return config
 }
@@ -49,7 +106,7 @@ func (sfs *SysctlFS) gatherList(file string, fields map[string]interface{}, fiel
 		if err != nil {
 			return err
 		}
-		fields[name] = v
+		fields[KeySysctlFsFieldNameMap[name]] = v
 	}
 
 	return nil
@@ -66,7 +123,7 @@ func (sfs *SysctlFS) gatherOne(name string, fields map[string]interface{}) error
 		return err
 	}
 
-	fields[name] = v
+	fields[KeySysctlFsFieldNameMap[name]] = v
 	return nil
 }
 
@@ -86,7 +143,7 @@ func (sfs *SysctlFS) Collect() (datas []map[string]interface{}, err error) {
 }
 
 func init() {
-	metric.Add("linux_sysctl_fs", func() metric.Collector {
+	metric.Add(TypeLinuxSysctlFs, func() metric.Collector {
 		return &SysctlFS{
 			path: "/proc/sys/fs",
 		}

--- a/mgr/metric_runner.go
+++ b/mgr/metric_runner.go
@@ -68,6 +68,9 @@ func NewMetricRunner(rc RunnerConfig, sr *sender.SenderRegistry) (runner *Metric
 	if err != nil {
 		return nil, fmt.Errorf("Runner "+rc.RunnerName+" add failed, err is %v", err)
 	}
+	for i := range rc.SenderConfig {
+		rc.SenderConfig[i][sender.KeyRunnerName] = rc.RunnerName
+	}
 	collectors := make([]metric.Collector, 0)
 	transformers := make([]transforms.Transformer, 0)
 	if len(rc.MetricConfig) == 0 {


### PR DESCRIPTION

## Changes
   
  - [x] 修复添加普通 log runner 时，不初始化 collect_interval, 导致 json 校验失败的问题
  - [x] 修复 metric runner 的 Sender 中获取不到 RunnerName 导致日志中均为 UndefinedRunnerName 的问题
  - [x] 修复因linux_sysctl_fs中含有短横线命名的字段，导致向 pandora 平台发送数据被拒绝的问题
  - [x] 将各个信息采集模块显示顺序的排序逻辑放在后端
  - [x] metric或log runner添加到一半返回主页再进入另一种 runner 的添加页面时，从 nodeCopy 中删除与当前 runner 无关的字段
 
## Reviewers

  - [ ] @wonderflow  please review
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
