### PR TITLE
为 metric 信息定义统一的时间戳字段 timestamp, 修复了失败重发数据中重复添加 osinfo 的bug

### DIFF
--- a/metric/system/cpu.go
+++ b/metric/system/cpu.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -130,7 +129,6 @@ func (s *CPUStats) Collect() (datas []map[string]interface{}, err error) {
 		return nil, fmt.Errorf("error getting CPU info: %s", err)
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	for _, cts := range times {
 
 		total := totalCpuTime(cts)
@@ -150,7 +148,6 @@ func (s *CPUStats) Collect() (datas []map[string]interface{}, err error) {
 				CpuTimeGuestNice: cts.GuestNice,
 				CpuTimeCPU:       cts.CPU,
 			}
-			fieldsC[TypeMetricCpu+"_"+metric.Timestamp] = now
 			datas = append(datas, fieldsC)
 		}
 
@@ -186,7 +183,6 @@ func (s *CPUStats) Collect() (datas []map[string]interface{}, err error) {
 			CpuUsageGuestNice: 100 * (cts.GuestNice - lastCts.GuestNice) / totalDelta,
 			CpuUsageCPU:       cts.CPU,
 		}
-		fieldsG[TypeMetricCpu+"_"+metric.Timestamp] = now
 		datas = append(datas, fieldsG)
 	}
 

--- a/metric/system/disk.go
+++ b/metric/system/disk.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -96,7 +95,6 @@ func (s *DiskStats) Collect() (datas []map[string]interface{}, err error) {
 		return nil, fmt.Errorf("error getting disk usage info: %s", err)
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	for i, du := range disks {
 		if du.Total == 0 {
 			// Skip dummy filesystem (procfs, cgroupfs, ...)
@@ -120,7 +118,6 @@ func (s *DiskStats) Collect() (datas []map[string]interface{}, err error) {
 			KeyDiskInodesFree:  du.InodesFree,
 			KeyDiskInodesUsed:  du.InodesUsed,
 		}
-		fields[TypeMetricDisk+"_"+metric.Timestamp] = now
 		datas = append(datas, fields)
 	}
 	return
@@ -230,7 +227,6 @@ func (s *DiskIOStats) Collect() (datas []map[string]interface{}, err error) {
 		return nil, fmt.Errorf("error getting disk io info: %s", err)
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	for _, io := range diskio {
 		fields := map[string]interface{}{
 			KeyDiskioReads:          io.ReadCount,
@@ -253,7 +249,6 @@ func (s *DiskIOStats) Collect() (datas []map[string]interface{}, err error) {
 				fields[KeyDiskioSerial] = "unknown"
 			}
 		}
-		fields[TypeMetricDiskio+"_"+metric.Timestamp] = now
 		datas = append(datas, fields)
 	}
 	return

--- a/metric/system/kernel_linux.go
+++ b/metric/system/kernel_linux.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -76,7 +75,6 @@ func (k *Kernel) Collect() (datas []map[string]interface{}, err error) {
 		return nil, err
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	fields := make(map[string]interface{})
 	dataFields := bytes.Fields(data)
 	for i, field := range dataFields {
@@ -118,8 +116,6 @@ func (k *Kernel) Collect() (datas []map[string]interface{}, err error) {
 			fields[KernelDiskPagesOut] = int64(out)
 		}
 	}
-
-	fields[TypeMetricKernel+"_"+metric.Timestamp] = now
 	datas = append(datas, fields)
 	return
 }

--- a/metric/system/kernel_vmstat_linux.go
+++ b/metric/system/kernel_vmstat_linux.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -49,7 +48,6 @@ func (k *KernelVmstat) Collect() (datas []map[string]interface{}, err error) {
 		return nil, err
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	fields := make(map[string]interface{})
 	dataFields := bytes.Fields(data)
 	for i, field := range dataFields {
@@ -67,10 +65,7 @@ func (k *KernelVmstat) Collect() (datas []map[string]interface{}, err error) {
 			fields[key] = int64(m)
 		}
 	}
-	if len(fields) > 0 {
-		fields["kernel_vmstat_"+metric.Timestamp] = now
-		datas = append(datas, fields)
-	}
+	datas = append(datas, fields)
 	return
 }
 

--- a/metric/system/linux_sysctl_fs.go
+++ b/metric/system/linux_sysctl_fs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"strconv"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -135,7 +134,6 @@ func (sfs *SysctlFS) gatherOne(name string, fields map[string]interface{}) error
 func (sfs *SysctlFS) Collect() (datas []map[string]interface{}, err error) {
 	fields := map[string]interface{}{}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	for _, n := range []string{"aio-nr", "aio-max-nr", "dquot-nr", "dquot-max", "super-nr", "super-max"} {
 		sfs.gatherOne(n, fields)
 	}
@@ -144,10 +142,7 @@ func (sfs *SysctlFS) Collect() (datas []map[string]interface{}, err error) {
 	sfs.gatherList("dentry-state", fields, "dentry-nr", "dentry-unused-nr", "dentry-age-limit", "dentry-want-pages")
 	sfs.gatherList("file-nr", fields, "file-nr", "", "file-max")
 
-	if len(fields) > 0 {
-		fields["linux_sysctl_fs_"+metric.Timestamp] = now
-		datas = append(datas, fields)
-	}
+	datas = append(datas, fields)
 	return
 }
 

--- a/metric/system/memory.go
+++ b/metric/system/memory.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -69,7 +68,6 @@ func (s *MemStats) Collect() (datas []map[string]interface{}, err error) {
 		return nil, fmt.Errorf("error getting virtual memory info: %s", err)
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	fields := map[string]interface{}{
 		KeyMemTotal:            vm.Total,
 		KeyMemAvailable:        vm.Available,
@@ -82,7 +80,6 @@ func (s *MemStats) Collect() (datas []map[string]interface{}, err error) {
 		KeyMemUsedPercent:      100 * float64(vm.Used) / float64(vm.Total),
 		KeyMemAvailablePercent: 100 * float64(vm.Available) / float64(vm.Total),
 	}
-	fields[TypeMetricMem+"_"+metric.Timestamp] = now
 	datas = append(datas, fields)
 	return
 }
@@ -140,7 +137,6 @@ func (s *SwapStats) Collect() (datas []map[string]interface{}, err error) {
 		return nil, fmt.Errorf("error getting swap memory info: %s", err)
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	fieldsG := map[string]interface{}{
 		KeySwapIn:          swap.Sin,
 		KeySwapOut:         swap.Sout,
@@ -149,7 +145,6 @@ func (s *SwapStats) Collect() (datas []map[string]interface{}, err error) {
 		KeySwapFree:        swap.Free,
 		KeySwapUsedPercent: swap.UsedPercent,
 	}
-	fieldsG[TypeMetricSwap+"_"+metric.Timestamp] = now
 	datas = append(datas, fieldsG)
 	return
 }

--- a/metric/system/net.go
+++ b/metric/system/net.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -92,7 +91,6 @@ func (s *NetIOStats) Collect() (datas []map[string]interface{}, err error) {
 		return nil, fmt.Errorf("error getting net io info: %s", err)
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	for _, io := range netio {
 		if len(s.Interfaces) != 0 {
 			var found bool
@@ -133,7 +131,6 @@ func (s *NetIOStats) Collect() (datas []map[string]interface{}, err error) {
 			KeyNetDropOut:     io.Dropout,
 			KeyNetInterface:   io.Name,
 		}
-		fields[TypeMetricNet+"_"+metric.Timestamp] = now
 		datas = append(datas, fields)
 	}
 
@@ -149,7 +146,6 @@ func (s *NetIOStats) Collect() (datas []map[string]interface{}, err error) {
 			}
 		}
 		fields[KeyNetInterface] = "all"
-		fields[TypeMetricNet+"_"+metric.Timestamp] = now
 		datas = append(datas, fields)
 	}
 	return

--- a/metric/system/netstat.go
+++ b/metric/system/netstat.go
@@ -3,7 +3,6 @@ package system
 import (
 	"fmt"
 	"syscall"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -76,7 +75,6 @@ func (s *NetStats) Collect() (datas []map[string]interface{}, err error) {
 		return nil, fmt.Errorf("error getting net connections info: %s", err)
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
 	counts := make(map[string]int)
 	counts["UDP"] = 0
 
@@ -108,7 +106,6 @@ func (s *NetStats) Collect() (datas []map[string]interface{}, err error) {
 		KeyNetstatTcpNone:        counts["NONE"],
 		KeyNetstatUdpSocket:      counts["UDP"],
 	}
-	fields[TypeMetricNetstat+"_"+metric.Timestamp] = now
 	datas = append(datas, fields)
 	return
 }

--- a/metric/system/processes.go
+++ b/metric/system/processes.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"strconv"
 	"syscall"
-	"time"
 
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/utils"
@@ -107,8 +106,6 @@ func (p *Processes) Collect() (datas []map[string]interface{}, err error) {
 			return nil, err
 		}
 	}
-	now := time.Now().Format(time.RFC3339Nano)
-	fields[TypeMetricProcesses+"_"+metric.Timestamp] = now
 	datas = append(datas, fields)
 	return
 }

--- a/metric/system/system.go
+++ b/metric/system/system.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"runtime"
-	"time"
 
 	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/load"
@@ -87,8 +86,6 @@ func (_ *SystemStats) Collect() (datas []map[string]interface{}, err error) {
 		KeySystemUptime:       hostinfo.Uptime,
 		KeySystemUptimeFormat: format_uptime(hostinfo.Uptime),
 	}
-	now := time.Now().Format(time.RFC3339Nano)
-	data[TypeMetricSystem+"_"+metric.Timestamp] = now
 	datas = append(datas, data)
 	return
 }

--- a/mgr/metric_runner.go
+++ b/mgr/metric_runner.go
@@ -1,13 +1,13 @@
 package mgr
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"encoding/json"
 
 	"github.com/qiniu/log"
 	"github.com/qiniu/logkit/conf"
@@ -36,8 +36,8 @@ type MetricRunner struct {
 	RunnerName string `json:"name"`
 
 	collectors   []metric.Collector
-	transformers []transforms.Transformer
 	senders      []sender.Sender
+	transformers map[string][]transforms.Transformer
 
 	collectInterval time.Duration
 	rs              RunnerStatus
@@ -73,7 +73,7 @@ func NewMetricRunner(rc RunnerConfig, sr *sender.SenderRegistry) (runner *Metric
 		rc.SenderConfig[i][sender.KeyRunnerName] = rc.RunnerName
 	}
 	collectors := make([]metric.Collector, 0)
-	transformers := make([]transforms.Transformer, 0)
+	transformers := make(map[string][]transforms.Transformer)
 	if len(rc.MetricConfig) == 0 {
 		return nil, fmt.Errorf("Runner " + rc.RunnerName + " has zero metric, ignore it")
 	}
@@ -97,20 +97,23 @@ func NewMetricRunner(rc RunnerConfig, sr *sender.SenderRegistry) (runner *Metric
 
 		// 配置文件中明确标明 false 的 attr 加入 discard transformer
 		config := c.Config()
+		metricName := c.Name()
+		trans := make([]transforms.Transformer, 0)
 		if attributes, ex := config[metric.AttributesString]; ex {
 			if attrs, ok := attributes.([]utils.KeyValue); ok {
 				for _, attr := range attrs {
 					val, exist := m.Attributes[attr.Key]
 					if exist && !val {
-						trans, err := createDiscardTransformer(attr.Key)
+						DisTrans, err := createDiscardTransformer(attr.Key)
 						if err != nil {
 							return nil, fmt.Errorf("metric %v key %v, transform add failed, %v", tp, attr.Key, err)
 						}
-						transformers = append(transformers, trans)
+						trans = append(trans, DisTrans)
 					}
 				}
 			}
 		}
+		transformers[metricName] = trans
 	}
 	if len(collectors) < 1 {
 		err = errors.New("no collectors were added")
@@ -166,46 +169,64 @@ func (r *MetricRunner) Run() {
 			r.exitChan <- struct{}{}
 			return
 		}
+		// collect data
 		dataCnt := 0
 		datas := make([]sender.Data, 0)
-		// collect data
+		now := time.Now().Format(time.RFC3339Nano)
 		for _, c := range r.collectors {
+			metricName := c.Name()
 			tmpdatas, err := c.Collect()
 			if err != nil {
 				log.Errorf("collecter <%v> collect data error: %v", c.Name(), err)
 				continue
 			}
-			for i := range tmpdatas {
-				if len(tmpdatas[i]) > 0 {
-					dataCnt++
-					datas = append(datas, tmpdatas[i])
+			dataLen := len(tmpdatas)
+			nameLen := len(metricName)
+			if dataLen == 0 {
+				log.Debugf("MetricRunner %v collect No data", c.Name())
+				continue
+			}
+			tmpDatas := make([]sender.Data, dataLen)
+			for i, d := range tmpdatas {
+				tmpDatas[i] = d
+			}
+			if trans, ok := r.transformers[metricName]; ok {
+				for _, t := range trans {
+					tmpDatas, err = t.Transform(tmpDatas)
+					if err != nil {
+						log.Error(err)
+					}
 				}
 			}
-			if len(tmpdatas) < 1 {
-				log.Debugf("MetricRunner %v collect No data", c.Name())
+			for _, metricData := range tmpDatas {
+				if len(metricData) == 0 {
+					continue
+				}
+				data := sender.Data{
+					metric.Timestamp: now,
+				}
+				// 重命名
+				// cpu_time_user --> cpu__time_user
+				for m, d := range metricData {
+					newName := m
+					if strings.HasPrefix(m, metricName) {
+						newName = metricName + "_" + m[nameLen:]
+					}
+					data[newName] = d
+				}
+				datas = append(datas, data)
+				dataCnt++
 			}
+		}
+		if len(datas) == 0 {
+			log.Warnf("metrics collect no data")
+			time.Sleep(r.collectInterval)
+			continue
 		}
 		r.rsMutex.Lock()
 		r.rs.ReadDataCount += int64(dataCnt)
 		r.rsMutex.Unlock()
 		r.lastSend = time.Now()
-		if len(datas) <= 0 {
-			log.Debug("MetricRunner collect No data")
-			time.Sleep(r.collectInterval)
-			continue
-		}
-		var err error
-		for i := range r.transformers {
-			datas, err = r.transformers[i].Transform(datas)
-			if err != nil {
-				log.Error(err)
-			}
-		}
-		if len(datas) <= 0 {
-			log.Warnf("data has been cleared by transformer")
-			time.Sleep(r.collectInterval)
-			continue
-		}
 		for _, s := range r.senders {
 			if !r.trySend(s, datas, 3) {
 				log.Errorf("failed to send metricData: << %v >>", datas)

--- a/mgr/metric_runner_test.go
+++ b/mgr/metric_runner_test.go
@@ -122,13 +122,13 @@ func TestMetricRun(t *testing.T) {
 	f, err := os.Open(fileSenderData)
 	assert.NoError(t, err)
 	br := bufio.NewReaderSize(f, bufSize)
-	result := make([]map[string]interface{}, 0)
 	for {
 		str, _, c := br.ReadLine()
 		if c == io.EOF {
 			f.Close()
 			break
 		}
+		result := make([]map[string]interface{}, 0)
 		err = json.Unmarshal([]byte(str), &result)
 		if err != nil {
 			log.Fatalf("Test_Run error unmarshal %v curLine = %v %v", string(str), curLine, err)
@@ -200,13 +200,13 @@ func TestMetricRun(t *testing.T) {
 	f, err = os.Open(fileSenderData1)
 	assert.NoError(t, err)
 	br = bufio.NewReaderSize(f, bufSize)
-	result = make([]map[string]interface{}, 0)
 	for {
 		str, _, c := br.ReadLine()
 		if c == io.EOF {
 			f.Close()
 			break
 		}
+		result := make([]map[string]interface{}, 0)
 		err = json.Unmarshal([]byte(str), &result)
 		if err != nil {
 			log.Fatalf("Test_Run error unmarshal %v curLine = %v %v", string(str), curLine, err)

--- a/sender/pandora_sender_test.go
+++ b/sender/pandora_sender_test.go
@@ -1115,8 +1115,6 @@ func TestPandoraExtraInfo(t *testing.T) {
 	}
 	resp := pandora.Body
 	assert.Equal(t, true, strings.Contains(resp, "core"))
-	assert.Equal(t, true, strings.Contains(resp, "osinfo0"))
-	assert.Equal(t, true, strings.Contains(resp, "hostname3"))
 	assert.Equal(t, true, strings.Contains(resp, "x1=123.2"))
 	assert.Equal(t, true, strings.Contains(resp, "osinfo=123.2"))
 	assert.Equal(t, true, strings.Contains(resp, "hostname=123.2"))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,10 @@ import (
 
 const (
 	GlobalKeyName = "name"
+	KeyCore       = "core"
+	KeyHostName   = "hostname"
+	KeyOsInfo     = "osinfo"
+	KeyLocalIp    = "localip"
 )
 
 type File struct {
@@ -262,11 +266,11 @@ func (oi *OSInfo) String() string {
 func GetExtraInfo() map[string]string {
 	osInfo := GetOSInfo()
 	exInfo := make(map[string]string)
-	exInfo["core"] = osInfo.Core
-	exInfo["hostname"] = osInfo.Hostname
-	exInfo["osinfo"] = osInfo.OS + "-" + osInfo.Kernel + "-" + osInfo.Platform
+	exInfo[KeyCore] = osInfo.Core
+	exInfo[KeyHostName] = osInfo.Hostname
+	exInfo[KeyOsInfo] = osInfo.OS + "-" + osInfo.Kernel + "-" + osInfo.Platform
 	if ip, err := GetLocalIP(); err != nil {
-		exInfo["localip"] = ip
+		exInfo[KeyLocalIp] = ip
 	}
 	return exInfo
 }

--- a/vendor/github.com/qiniu/pandora-go-sdk/base/reqerr/error.go
+++ b/vendor/github.com/qiniu/pandora-go-sdk/base/reqerr/error.go
@@ -117,6 +117,8 @@ const (
 	ErrSameToSystemVariable
 	ErrTransformUpdate
 	ErrSQLWithUndefinedVariable
+	ErrWorkflowNameSameToRepoOrDatasource
+	ErrJobReRunOrCancel
 )
 
 type ErrBuilder interface {

--- a/vendor/github.com/qiniu/pandora-go-sdk/pipeline/api.go
+++ b/vendor/github.com/qiniu/pandora-go-sdk/pipeline/api.go
@@ -1031,7 +1031,7 @@ func (c *Pipeline) CreateForMutiExportTSDB(input *CreateRepoForMutiExportTSDBInp
 		if err != nil && !reqerr.IsExistError(err) {
 			return err
 		}
-		tsdbSpec := c.FormTSDBSpec(&CreateRepoForTSDBInput{
+		tsdbSpec := c.FormMutiSeriesTSDBSpec(&CreateRepoForTSDBInput{
 			RepoName:     input.RepoName,
 			TSDBRepoName: input.TSDBRepoName,
 			Region:       input.Region,

--- a/vendor/github.com/qiniu/pandora-go-sdk/pipeline/error.go
+++ b/vendor/github.com/qiniu/pandora-go-sdk/pipeline/error.go
@@ -194,6 +194,10 @@ func (e PipelineErrBuilder) Build(msg, text, reqId string, code int) error {
 		err.ErrorType = reqerr.ErrSQLWithUndefinedVariable
 	case "E18660":
 		err.ErrorType = reqerr.ErrTransformUpdate
+	case "E18661":
+		err.ErrorType = reqerr.ErrWorkflowNameSameToRepoOrDatasource
+	case "E18662":
+		err.ErrorType = reqerr.ErrJobReRunOrCancel
 	case "E9000":
 		err.ErrorType = reqerr.InternalServerError
 	case "E9001":

--- a/vendor/github.com/qiniu/pandora-go-sdk/pipeline/models.go
+++ b/vendor/github.com/qiniu/pandora-go-sdk/pipeline/models.go
@@ -617,8 +617,8 @@ type AutoExportToTSDBInput struct {
 	OmitEmpty    bool
 	Timestamp    string
 	IsMetric     bool
+	ExpandAttr   []string
 	SeriesTags   map[string][]string
-	ExpandAttr   []RepoSchemaEntry
 }
 
 type CreateRepoForTSDBInput struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -217,8 +217,8 @@
 		{
 			"checksumSHA1": "FD0NPm5c4QKtHCYvITcZEHxLKlU=",
 			"path": "github.com/qiniu/pandora-go-sdk/base",
-			"revision": "b6701f5a7721af43439886e83cbdf3d37ad449d1",
-			"revisionTime": "2017-11-28T11:18:40Z"
+			"revision": "ebf3672aa138bb9b04e8c9266d2305fd051b266b",
+			"revisionTime": "2017-11-28T02:41:05Z"
 		},
 		{
 			"checksumSHA1": "zwVutdUGEo/jlq6HpXkGwaoHM6c=",
@@ -233,10 +233,10 @@
 			"revisionTime": "2017-11-28T11:18:40Z"
 		},
 		{
-			"checksumSHA1": "l6ZGFpujKwObrRwajNScqwUWdOc=",
+			"checksumSHA1": "MBe33LOo6OxWIZCs9pqa7ePb8cg=",
 			"path": "github.com/qiniu/pandora-go-sdk/base/reqerr",
-			"revision": "b6701f5a7721af43439886e83cbdf3d37ad449d1",
-			"revisionTime": "2017-11-28T11:18:40Z"
+			"revision": "ebf3672aa138bb9b04e8c9266d2305fd051b266b",
+			"revisionTime": "2017-11-28T02:41:05Z"
 		},
 		{
 			"checksumSHA1": "EU8tbJXzlD16NONu4g6rVdDQQM4=",
@@ -251,10 +251,10 @@
 			"revisionTime": "2017-11-28T11:18:40Z"
 		},
 		{
-			"checksumSHA1": "x+6sMXZo7yQj2B9Po3MHhPDIckE=",
+			"checksumSHA1": "n6uBujsdJLZ+8x/LmThncMsjTdM=",
 			"path": "github.com/qiniu/pandora-go-sdk/pipeline",
-			"revision": "b6701f5a7721af43439886e83cbdf3d37ad449d1",
-			"revisionTime": "2017-11-28T11:18:40Z"
+			"revision": "ebf3672aa138bb9b04e8c9266d2305fd051b266b",
+			"revisionTime": "2017-11-28T02:41:05Z"
 		},
 		{
 			"checksumSHA1": "fjT/MuiyHbBoZ2zjj2kCnpUkYcw=",


### PR DESCRIPTION
## Changes
   
  - [ ] 修复了失败重发数据中重复添加 osInfo 的 bug
  - [ ] 为 metric 定义统一的时间戳字段 timestamp
  - [ ] 用双下划线来发送到 repo 时，用双下划线来分割series name
  - [ ] 导出到 tsdb 时不再忽略非法值，以便及时了解错误信息，避免出现导出数据全部为空的情况发生。
 
## Reviewers

  - [ ] @wonderflow  please review
  - [ ] @[someotherone] please review

## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
