### PR TITLE
CI 测试时，只用 go1.9 版本，不再使用 go1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.8
   - 1.9
 script:
   - make test


### PR DESCRIPTION

## Changes
   
  - [ ] CI 测试时，只用 go1.9 版本，不再使用 go1.8
 
## Reviewers

  - [ ] @wonderflow  please review

## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
