### PR TITLE
检测下一个log文件时,对文件修改时间做纳秒级比较,解决两个文件修改时间特别接近时,略过一些文件的问题

### DIFF
--- a/reader/seqfile.go
+++ b/reader/seqfile.go
@@ -305,7 +305,7 @@ func (sf *SeqFile) nextFile() (fi os.FileInfo, err error) {
 		condition = sf.getIgnoreCondition()
 	} else {
 		newerThanCurrFile := func(f os.FileInfo) bool {
-			return f.ModTime().Unix() > currFi.ModTime().Unix()
+			return f.ModTime().UnixNano() > currFi.ModTime().UnixNano()
 		}
 		condition = andCondition(newerThanCurrFile, sf.getIgnoreCondition())
 	}


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
  - [ ] 检测下一个log文件时,对文件修改时间做纳秒级比较,解决两个文件修改时间特别接近时,略过一些文件的问题

## Reviewers

  - [ ] @wonderflow  please review

## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
