### PR TITLE
Fix kubernetes transformer functions

### DIFF
--- a/transforms/service/k8stag.go
+++ b/transforms/service/k8stag.go
@@ -17,7 +17,8 @@ const (
 	K8sTagType   = "k8stag"
 	K8sPodName   = "k8s_pod_name"
 	K8sNamespace = "k8s_namespace"
-	K8sContainer = "k8s_container"
+	K8sContainerName = "k8s_container_name"
+        K8sContainerId   = "k8s_container_id"
 )
 
 type K8sTag struct {
@@ -54,7 +55,10 @@ func (g *K8sTag) Transform(datas []sender.Data) ([]sender.Data, error) {
 		}
 		datas[i][K8sPodName] = splits[0]
 		datas[i][K8sNamespace] = splits[1]
-		datas[i][K8sContainer] = strings.TrimSuffix(strings.Join(splits[2:], "_"), ".log")
+		container_info := strings.TrimSuffix(strings.Join(splits[2:], "_"), ".log")
+                container_info_splits := strings.Split(container_info, "-")
+                datas[i][K8sContainerId] = container_info_splits[len(container_info_splits)-1]
+                datas[i][K8sContainerName] = strings.Join(container_info_splits[0:len(container_info_splits)-1], "-")
 	}
 	if err != nil {
 		g.stats.LastError = err.Error()

--- a/transforms/service/k8stag_test.go
+++ b/transforms/service/k8stag_test.go
@@ -15,8 +15,8 @@ func TestK8sTransformer(t *testing.T) {
 	data, err := ktag.Transform([]sender.Data{{"sourcetag": "/var/logs/containers/admin-220-jrhnr_zhujiali_admin-92.log", "abc": "x1 y2"}, {"sourcetag": "atnet-status-29419-1_ava_atnet-status-27.log", "abc": "x1"}})
 	assert.NoError(t, err)
 	exp := []sender.Data{
-		{"sourcetag": "/var/logs/containers/admin-220-jrhnr_zhujiali_admin-92.log", K8sPodName: "admin-220-jrhnr", K8sNamespace: "zhujiali", K8sContainer: "admin-92", "abc": "x1 y2"},
-		{"sourcetag": "atnet-status-29419-1_ava_atnet-status-27.log", K8sPodName: "atnet-status-29419-1", K8sNamespace: "ava", K8sContainer: "atnet-status-27", "abc": "x1"}}
+		{"sourcetag": "/var/logs/containers/admin-220-jrhnr_zhujiali_admin-92.log", K8sPodName: "admin-220-jrhnr", K8sNamespace: "zhujiali", K8sContainerName: "admin", K8sContainerId: "92", "abc": "x1 y2"},
+		{"sourcetag": "atnet-status-29419-1_ava_atnet-status-27.log", K8sPodName: "atnet-status-29419-1", K8sNamespace: "ava", K8sContainerName: "atnet-status", K8sContainerId: "27", "abc": "x1"}}
 	assert.Equal(t, exp, data)
 
 	assert.Equal(t, ktag.Stage(), transforms.StageAfterParser)


### PR DESCRIPTION
## Fixes [issue number]

None

## Changes

让 k8s_tag transformer 支持的功能更加合理

k8s 存储 pod 中每一个容器的日志的日志文件名格式为

<pod_name>_<namespace>_<container_name>-<container_id>.log

比如
kube-proxy-00zrx_kube-system_kube-proxy-3e1efd2142307a5f3d324455899f9009e1d6ff060016cc63e4302886f4215a3a.log

pod_name: kube-proxy-00zrx
namespace: kube-system
container_name: kube-proxy
container_id: 3e1efd2142307a5f3d324455899f9009e1d6ff060016cc63e4302886f4215a3a

这个 PR，就是为了丰富 k8s_tag transformer 的功能，使他能够提供 k8s_container_name, k8s_container_id 两个字段
 
## Reviewers

  - [ ] @wonderflow please review

## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
