### PR TITLE
使用decode来代替unmarshal,避免将int64变为科学计数法,导致后续解析出错的问题

### DIFF
--- a/parser/csv_parser.go
+++ b/parser/csv_parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -323,7 +324,9 @@ func (f field) ValueParse(value string, timeZoneOffset int) (datas sender.Data, 
 			return
 		}
 		m := make(map[string]interface{})
-		if err = json.Unmarshal([]byte(value), &m); err != nil {
+		d := json.NewDecoder(bytes.NewReader([]byte(value)))
+		d.UseNumber()
+		if err = d.Decode(&m); err != nil {
 			err = fmt.Errorf("unmarshal json map type error: %v", err)
 			return
 		}

--- a/parser/csv_parser_test.go
+++ b/parser/csv_parser_test.go
@@ -61,7 +61,7 @@ func Test_CsvParser(t *testing.T) {
 	exp["a"] = int64(123)
 	exp["b"] = "fufu"
 	exp["c"] = 3.14
-	exp["d-x"] = float64(1)
+	exp["d-x"] = json.Number("1")
 	exp["d-y"] = "2"
 	exp["e"] = tmstr
 	for k, v := range datas[0] {
@@ -104,8 +104,8 @@ func Test_Jsonmap(t *testing.T) {
 		t.Error(err)
 	}
 	d := datas[0]
-	if d["f-x"] != 1.0 {
-		t.Errorf("f-x should be float 1 but %v %v", reflect.TypeOf(d["f-x"]), d["f-x"])
+	if d["f-x"] != json.Number("1.0") {
+		t.Errorf("f-x should be json.Number 1.0 but %v %v", reflect.TypeOf(d["f-x"]), d["f-x"])
 	}
 	if d["f-z"] != 3.0 {
 		t.Errorf("f-z should be float 3.0 but type %v %v", reflect.TypeOf(d["f-z"]), d["f-z"])


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
  - [ ] 使用decode来代替unmarshal,避免将int64变为科学计数法,导致后续解析出错的问题
## Reviewers

  - [ ] @wonderflow  please review
## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
