### PR TITLE
NewMetricRuuner的时候支持从外部传入SenderRegistry

### DIFF
--- a/mgr/runner.go
+++ b/mgr/runner.go
@@ -148,7 +148,7 @@ func NewCustomRunner(rc RunnerConfig, cleanChan chan<- cleaner.CleanSignal, ps *
 		sr = sender.NewSenderRegistry()
 	}
 	if rc.MetricConfig != nil {
-		return NewMetricRunner(rc, sender.NewSenderRegistry())
+		return NewMetricRunner(rc, sr)
 	}
 	return NewLogExportRunner(rc, cleanChan, ps, sr)
 }


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
  - [ ] 如题，在使用MetricRunner的时候也能用到外面传进来的SenderRegistry，方便用户把logkit作为库来采集metric数据
 
## Reviewers

  - [ ] @wonderflow  please review
  - [ ] @andrewei1316  please review

## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
