### PR TITLE
增加web的开关选项,给前端的配置Option中加入一个字段Secret(true/false)

### DIFF
--- a/mgr/mgr.go
+++ b/mgr/mgr.go
@@ -26,10 +26,11 @@ var DEFAULT_LOGKIT_REST_DIR = "/.logkitconfs"
 type ManagerConfig struct {
 	BindHost string `json:"bind_host"`
 
-	Idc     string        `json:"idc"`
-	Zone    string        `json:"zone"`
-	RestDir string        `json:"rest_dir"`
-	Cluster ClusterConfig `json:"cluster"`
+	Idc        string        `json:"idc"`
+	Zone       string        `json:"zone"`
+	RestDir    string        `json:"rest_dir"`
+	Cluster    ClusterConfig `json:"cluster"`
+	DisableWeb bool          `json:"disable_web"`
 }
 
 type cleanQueue struct {

--- a/mgr/rest.go
+++ b/mgr/rest.go
@@ -136,6 +136,10 @@ func NewRestService(mgr *Manager, router *echo.Echo) *RestService {
 		if port > 10000 {
 			log.Fatal("bind port failed too many times, exit...")
 		}
+		if mgr.DisableWeb {
+			break
+		}
+
 		address = ":" + strconv.Itoa(port)
 		if mgr.BindHost != "" {
 			address, httpschema = utils.RemoveHttpProtocal(mgr.BindHost)
@@ -155,9 +159,11 @@ func NewRestService(mgr *Manager, router *echo.Echo) *RestService {
 	}
 	rs.l = listener
 	log.Infof("successfully start RestService and bind address on %v", address)
-	err = generateStatsShell(address, PREFIX)
-	if err != nil {
-		log.Warn(err)
+	if !mgr.DisableWeb {
+		err = generateStatsShell(address, PREFIX)
+		if err != nil {
+			log.Warn(err)
+		}
 	}
 	rs.address = address
 	if rs.cluster.Enable {
@@ -272,6 +278,7 @@ func convertWebParserConfig(conf conf.MapConf) conf.MapConf {
 	if conf == nil {
 		return conf
 	}
+
 	rawCustomPatterns, _ := conf.GetStringOr(parser.KeyGrokCustomPatterns, "")
 	if rawCustomPatterns != "" {
 		CustomPatterns, err := base64.StdEncoding.DecodeString(rawCustomPatterns)

--- a/sender/rest_sender_models.go
+++ b/sender/rest_sender_models.go
@@ -111,6 +111,7 @@ var ModeKeyOptions = map[string][]utils.Option{
 			Default:      "在此填写您七牛账号的secret_key",
 			DefaultNoUse: true,
 			Description:  "七牛的私钥(secret_key)",
+			Secret:       true,
 		},
 		OptionSaveLogPath,
 		{

--- a/utils/models.go
+++ b/utils/models.go
@@ -9,6 +9,7 @@ type Option struct {
 	Description   string
 	CheckRegex    string
 	Type          string `json:"Type,omitempty"`
+	Secret        bool
 }
 
 type KeyValue struct {


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
  - [ ] 开启了web后对于用户的隐私数据采用加密显示，没开启的不作变动(这里要增加web的开关选项)
  - [ ] 在主配置中加入 总控 secret 配置，可以从环境变量中读，也可以直接指定secret，如果为空，使用默认的secret
  - [ ] 所有返回给前端的配置Option中加入一个字段Secret(true/false)，当secret为true时，以密码框显示输入
  - [ ] 对于Secret为true的字段，返回给前端或者保存到本地备份的json配置，要用总控secret加密
 
## Reviewers

  - [ ] @wonderflow  please review
  - [ ] @andrewei1316  please review