### PR TITLE
fix cleaner

### DIFF
--- a/cleaner/cleaner.go
+++ b/cleaner/cleaner.go
@@ -174,3 +174,7 @@ func (c *Cleaner) Clean() (err error) {
 	}
 	return nil
 }
+
+func (c *Cleaner) LogDir() string {
+	return c.logdir
+}

--- a/mgr/runner.go
+++ b/mgr/runner.go
@@ -678,11 +678,13 @@ func (r *LogExportRunner) Reset() (err error) {
 }
 
 func (r *LogExportRunner) Cleaner() CleanInfo {
-	ci := CleanInfo{
-		enable: r.cleaner != nil,
-		logdir: filepath.Dir(r.reader.Source()),
+	if r.cleaner == nil {
+		return CleanInfo{enable: false}
 	}
-	return ci
+	return CleanInfo{
+		enable: true,
+		logdir: r.cleaner.LogDir(),
+	}
 }
 
 func (r *LogExportRunner) batchFullOrTimeout() bool {

--- a/mgr/runner_test.go
+++ b/mgr/runner_test.go
@@ -110,7 +110,10 @@ func Test_Run(t *testing.T) {
 		t.Error(err)
 	}
 	cleanChan := make(chan cleaner.CleanSignal)
-	cleaner, err := cleaner.NewCleaner(conf.MapConf{}, meta, cleanChan, readerConfig["log_path"])
+	cleanerConfig := conf.MapConf{
+		"delete_enable": "true",
+	}
+	cleaner, err := cleaner.NewCleaner(cleanerConfig, meta, cleanChan, meta.LogPath())
 	if err != nil {
 		t.Error(err)
 	}
@@ -149,7 +152,7 @@ func Test_Run(t *testing.T) {
 	}
 
 	cleanInfo := CleanInfo{
-		enable: false,
+		enable: true,
 		logdir: absLogpath,
 	}
 	assert.Equal(t, cleanInfo, r.Cleaner())
@@ -258,7 +261,10 @@ func Test_RunForEnvTag(t *testing.T) {
 		t.Error(err)
 	}
 	cleanChan := make(chan cleaner.CleanSignal)
-	cleaner, err := cleaner.NewCleaner(conf.MapConf{}, meta, cleanChan, readerConfig["log_path"])
+	cleanerConfig := conf.MapConf{
+		"delete_enable": "true",
+	}
+	cleaner, err := cleaner.NewCleaner(cleanerConfig, meta, cleanChan, meta.LogPath())
 	if err != nil {
 		t.Error(err)
 	}
@@ -297,7 +303,7 @@ func Test_RunForEnvTag(t *testing.T) {
 	}
 
 	cleanInfo := CleanInfo{
-		enable: false,
+		enable: true,
 		logdir: absLogpath,
 	}
 	assert.Equal(t, cleanInfo, r.Cleaner())
@@ -406,7 +412,10 @@ func Test_RunForErrData(t *testing.T) {
 		t.Error(err)
 	}
 	cleanChan := make(chan cleaner.CleanSignal)
-	cleaner, err := cleaner.NewCleaner(conf.MapConf{}, meta, cleanChan, readerConfig["log_path"])
+	cleanerConfig := conf.MapConf{
+		"delete_enable": "true",
+	}
+	cleaner, err := cleaner.NewCleaner(cleanerConfig, meta, cleanChan, meta.LogPath())
 	if err != nil {
 		t.Error(err)
 	}
@@ -445,7 +454,7 @@ func Test_RunForErrData(t *testing.T) {
 	}
 
 	cleanInfo := CleanInfo{
-		enable: false,
+		enable: true,
 		logdir: absLogpath,
 	}
 	assert.Equal(t, cleanInfo, r.Cleaner())


### PR DESCRIPTION
## Changes
   
  - [x] 修复 增加runner时reader读取目录为空导致cleaner失效的bug

调整 `LogExportRunner.Cleaner()` 逻辑，当 `cleaner != nil` 时，返回 `enable: true` 和 `logdir`，若
 `cleaner == nil`，则返回 `enable: false` 和 empty `logdir`。

## Reviewers

  - [ ] @wonderflow  please review
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
