### PR TITLE
Verbose bucker region error for cloudtrail reader

### DIFF
--- a/reader/cloudtrail.go
+++ b/reader/cloudtrail.go
@@ -359,7 +359,20 @@ func lookupBucket(bucketName string, auth aws.Auth, region string) (*s3.Bucket, 
 		log.Infof("found bucket %q in region %q", bucketName, region)
 		return bucket, nil
 	}
+	if bucketRegionError(err) {
+		return nil, fmt.Errorf("bucket %q not in region %q", bucketName, region)
+	}
 	return nil, fmt.Errorf("list bucket failed: %v", err)
+}
+
+func bucketRegionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "301 response missing Location header") {
+		return true
+	}
+	return false
 }
 
 func loadS3Files(bucket *s3.Bucket, path string, files map[string]bool, marker string) (map[string]bool, error) {


### PR DESCRIPTION
## Fixes [PDR-6012](https://jira.qiniu.io/browse/PDR-6012)

## Changes
   
  - [ ] 细化cloudreader列举bucket时出现region不匹配的错误
 
## Reviewers

  - [ ] @wonderflow  please review

## Wiki Changes
 
  - options1...
  - options2...
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Wiki updated
