### PR TITLE
Makefile: use 'go install' to replace 'go build'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all:
-	go generate; CGO_ENABLED=1 go build -v -o logkit
+	go generate
+	CGO_ENABLED=1 go install -v
+	mv ${GOPATH}/bin/logkit .
 
 install: all
 	@echo


### PR DESCRIPTION
'go install' caches intermediate .a files which could speed up compilation when unchanged.

## Fixes [PDR-6205](https://jira.qiniu.io/browse/PDR-6205)

## Changes
   
None
 
## Reviewers

  - [ ] @wonderflow please review

## Wiki Changes
 
None
    
## Checklist
   
   - [x] Rebased/mergable
   - [x] Tests pass
   - [x] Wiki updated
