### PR TITLE
metric: add memcached as PoC of integrating telegraf metric

### DIFF
--- a/logkit.go
+++ b/logkit.go
@@ -11,6 +11,9 @@ import (
 	"sort"
 	"time"
 
+	"github.com/labstack/echo"
+	"github.com/qiniu/log"
+
 	"github.com/qiniu/logkit/cli"
 	config "github.com/qiniu/logkit/conf"
 	_ "github.com/qiniu/logkit/metric/all"
@@ -19,10 +22,6 @@ import (
 	_ "github.com/qiniu/logkit/transforms/all"
 	. "github.com/qiniu/logkit/utils/models"
 	utilsos "github.com/qiniu/logkit/utils/os"
-
-	"github.com/qiniu/log"
-
-	"github.com/labstack/echo"
 )
 
 //Config of logkit
@@ -217,7 +216,6 @@ func usageExit(rc int) {
 //！！！注意： 自动生成 grok pattern代码，下述注释请勿删除！！！
 //go:generate go run generators/grok_pattern_generater.go
 func main() {
-
 	flag.Usage = func() { usageExit(0) }
 	flag.Parse()
 	switch {

--- a/metric/all/all.go
+++ b/metric/all/all.go
@@ -3,4 +3,6 @@ package all
 import (
 	_ "github.com/qiniu/logkit/metric/curl"
 	_ "github.com/qiniu/logkit/metric/system"
+	_ "github.com/qiniu/logkit/metric/telegraf"
+	_ "github.com/qiniu/logkit/metric/telegraf/memcached"
 )

--- a/metric/registry.go
+++ b/metric/registry.go
@@ -12,10 +12,15 @@ const (
 
 //Collector 收集metrics的接口
 type Collector interface {
+	// Name returns the name.
 	Name() string
+	// Tags returns available tags.
 	Tags() []string
+	// Usages returns usage information.
 	Usages() string
+	// Config returns config fields and options.
 	Config() map[string]interface{}
+	// Collect gathers metric infomration.
 	Collect() ([]map[string]interface{}, error)
 }
 
@@ -23,6 +28,7 @@ type Collector interface {
 // SyncConfig 与 Config 对应 获取配置项后同步配置给插件
 type ExtCollector interface {
 	Collector
+	// SyncConfig updates config options specifically for external metrics.
 	SyncConfig(map[string]interface{}) error
 }
 

--- a/metric/telegraf/memcached/memcached.go
+++ b/metric/telegraf/memcached/memcached.go
@@ -1,0 +1,88 @@
+package memcached
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/qiniu/log"
+
+	"github.com/influxdata/telegraf/plugins/inputs/memcached"
+	"github.com/qiniu/logkit/metric"
+	"github.com/qiniu/logkit/metric/telegraf"
+	. "github.com/qiniu/logkit/utils/models"
+)
+
+const MetricName = "memcached"
+
+func init() {
+	telegraf.AddUsage(MetricName, "Memcached(memcached)")
+	telegraf.AddConfig(MetricName, map[string]interface{}{
+		metric.OptionString: []Option{
+			{
+				KeyName:      "servers",
+				ChooseOnly:   false,
+				Default:      `localhost:11211`,
+				DefaultNoUse: true,
+				Description:  "服务器连接地址(逗号分隔多个)",
+				Type:         metric.ConsifTypeString,
+			},
+		},
+		metric.AttributesString: []KeyValue{
+			{"memcached_get_hits", "get命中次数"},
+			{"memcached_get_misses", "get未命中次数"},
+			{"memcached_evictions", "驱逐次数"},
+			{"memcached_limit_maxbytes", "限制大字节数"},
+			{"memcached_bytes", "字节数"},
+			{"memcached_uptime", "运行时间"},
+			{"memcached_curr_items", "当前数量"},
+			{"memcached_total_items", "总数量"},
+			{"memcached_curr_connections", "当前连接数"},
+			{"memcached_total_connections", "总连接数"},
+			{"memcached_connection_structures", "连接结构数"},
+			{"memcached_cmd_get", "get请求数"},
+			{"memcached_cmd_set", "set请求数"},
+			{"memcached_delete_hits", "delete命中次数"},
+			{"memcached_delete_misses", "delete未命中次数"},
+			{"memcached_incr_hits", "incr命中次数"},
+			{"memcached_incr_misses", "incr未命中次数"},
+			{"memcached_decr_hits", "decr命中次数"},
+			{"memcached_decr_misses", "decr未命中次数"},
+			{"memcached_cas_hits", ""},
+			{"memcached_cas_misses", "cas命中次数"},
+			{"memcached_bytes_read", "cas未命中次数"},
+			{"memcached_bytes_written", "响应字节数"},
+			{"memcached_threads", "线程数"},
+			{"memcached_conn_yields", "连接退让次数"},
+		},
+	})
+}
+
+type collector struct {
+	*telegraf.Collector
+}
+
+func (c *collector) SyncConfig(data map[string]interface{}) error {
+	mc, ok := c.Input.(*memcached.Memcached)
+	if !ok {
+		return errors.New("unexpected telegraf type, want '*memcached.Memcached'")
+	}
+
+	mc.Servers = strings.Split(data["servers"].(string), ",")
+	return nil
+}
+
+// NewCollector creates a new Memcached collector.
+func NewCollector() metric.Collector {
+	input := inputs.Inputs[MetricName]()
+
+	if _, err := toml.Decode(input.SampleConfig(), input); err != nil {
+		log.Errorf("metric: failed to decode sample config of memcached: %v", err)
+	}
+	return &collector{telegraf.NewCollector(MetricName, input)}
+}
+
+func init() {
+	metric.Add(MetricName, NewCollector)
+}

--- a/metric/telegraf/telegraf.go
+++ b/metric/telegraf/telegraf.go
@@ -1,0 +1,136 @@
+package telegraf
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/influxdata/telegraf"
+)
+
+// Accumulator implements telegraf.Accumulator.
+type Accumulator struct {
+	name     string
+	dataSets []map[string]interface{}
+	err      error
+}
+
+func (acc *Accumulator) AddFields(measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	t ...time.Time) {
+	data := make(map[string]interface{}, len(fields))
+	for k, v := range fields {
+		data[acc.name+"_"+k] = v
+	}
+	acc.dataSets = append(acc.dataSets, data)
+}
+
+func (acc *Accumulator) AddGauge(measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	t ...time.Time) {
+	acc.AddFields(measurement, fields, tags, t...)
+}
+
+func (acc *Accumulator) AddCounter(measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	t ...time.Time) {
+	acc.AddFields(measurement, fields, tags, t...)
+}
+
+func (acc *Accumulator) AddSummary(measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	t ...time.Time) {
+	acc.AddFields(measurement, fields, tags, t...)
+}
+
+func (acc *Accumulator) AddHistogram(measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	t ...time.Time) {
+	acc.AddFields(measurement, fields, tags, t...)
+}
+
+func (_ *Accumulator) SetPrecision(precision, interval time.Duration) {
+	panic("not implemented yet")
+}
+
+func (acc *Accumulator) AddError(err error) {
+	if acc.err != nil {
+		return
+	}
+	acc.err = err
+}
+
+var usages = map[string]string{}
+
+// AddUsage adds usage information to data table.
+func AddUsage(name, usage string) {
+	usages[name] = usage
+}
+
+// GetUsageByName returns usage information specific to logkit.
+func GetUsageByName(name string) string {
+	usage, has := usages[name]
+	if has {
+		return usage
+	}
+	return "usage not found"
+}
+
+var configs = map[string]map[string]interface{}{}
+
+// AddConfig adds config information to data table.
+func AddConfig(name string, config map[string]interface{}) {
+	configs[name] = config
+}
+
+// GetConfigByName returns config information specific to logkit.
+func GetConfigByName(name string) map[string]interface{} {
+	config, has := configs[name]
+	if has {
+		return config
+	}
+	return map[string]interface{}{"error": "config not found"}
+}
+
+// Collector converts inputs.Input to logkit format and implements metric.Collector.
+type Collector struct {
+	name string
+	telegraf.Input
+}
+
+// NewCollector creates new general collector.
+func NewCollector(name string, input telegraf.Input) *Collector {
+	return &Collector{
+		name:  name,
+		Input: input,
+	}
+}
+
+func (c *Collector) Name() string {
+	return c.name
+}
+
+func (c *Collector) Tags() []string {
+	return []string{}
+}
+
+func (c *Collector) Usages() string {
+	return GetUsageByName(c.name)
+}
+
+func (c *Collector) Config() map[string]interface{} {
+	return GetConfigByName(c.name)
+}
+
+func (c *Collector) Collect() ([]map[string]interface{}, error) {
+	acc := new(Accumulator)
+	if err := c.Gather(acc); err != nil {
+		return nil, fmt.Errorf("failed to gather %q from telegraf: %v", c.name, err)
+	}
+
+	return acc.dataSets, acc.err
+}

--- a/mgr/metric_runner.go
+++ b/mgr/metric_runner.go
@@ -10,6 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/json-iterator/go"
+	"github.com/qiniu/log"
+
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/metric"
 	"github.com/qiniu/logkit/metric/curl"
@@ -17,10 +20,6 @@ import (
 	"github.com/qiniu/logkit/sender"
 	"github.com/qiniu/logkit/transforms"
 	. "github.com/qiniu/logkit/utils/models"
-
-	"github.com/qiniu/log"
-
-	"github.com/json-iterator/go"
 )
 
 const (


### PR DESCRIPTION
## Fixes [PDR-6227](https://jira.qiniu.io/browse/PDR-6227)

## Changes
   
- 添加 telegraf 通用模块，统一封装所有 telegraf 子模块需要用到的部分
- 添加 memcached 作为样例，方便后续继续添加其它 telegraf 子模块

## Reviewers

- [ ] @wonderflow please review
    
## Checklist
   
- [x] Rebased/mergeable
- [ ] Tests pass
