### PR TITLE
transforms/ip: fix panic when transform data

### DIFF
--- a/transforms/ip/dat.go
+++ b/transforms/ip/dat.go
@@ -31,12 +31,7 @@ func newDatLocator(dataFile string) (*datLocator, error) {
 		return nil, err
 	}
 
-	loc, err := newDatLocatorWithData(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return loc, nil
+	return newDatLocatorWithData(data)
 }
 
 func (loc *datLocator) init(data []byte) error {

--- a/transforms/ip/ip.go
+++ b/transforms/ip/ip.go
@@ -38,10 +38,11 @@ func (_ *Transformer) RawTransform(datas []string) ([]string, error) {
 func (t *Transformer) Transform(datas []Data) ([]Data, error) {
 	var err, ferr error
 	if t.loc == nil {
-		t.loc, err = NewLocator(t.DataPath)
+		loc, err := NewLocator(t.DataPath)
 		if err != nil {
 			return datas, err
 		}
+		t.loc = loc
 	}
 	errnums := 0
 	keys := GetKeys(t.Key)


### PR DESCRIPTION
Even when NewLocator returns nil and assign to t.loc, because it is an interface, the t.loc itself no longer being nil.

JIRA: https://jira.qiniu.io/browse/PDR-6339
 
## Reviewers

- @wonderflow 
- @redHJ 

## Checklist
   
- [x] Rebased/mergeable
- [x] Tests pass
