### PR TITLE
transforms: add LocatorStore for IP to prevent init duplicated locators

### DIFF
--- a/mgr/dataflow.go
+++ b/mgr/dataflow.go
@@ -449,7 +449,7 @@ func getTransformer(transConfig map[string]interface{}, create transforms.Creato
 		return nil, jsonErr
 	}
 
-	if trans, ok := trans.(transforms.Initialize); ok {
+	if trans, ok := trans.(transforms.Initializer); ok {
 		if err := trans.Init(); err != nil {
 			return nil, err
 		}

--- a/mgr/runner.go
+++ b/mgr/runner.go
@@ -309,7 +309,7 @@ func createTransformers(rc RunnerConfig) ([]transforms.Transformer, error) {
 			return nil, fmt.Errorf("type %v of transformer unmarshal config error %v", strTP, err)
 		}
 		//transformer初始化
-		if trans, ok := trans.(transforms.Initialize); ok {
+		if trans, ok := trans.(transforms.Initializer); ok {
 			err = trans.Init()
 			if err != nil {
 				return nil, fmt.Errorf("type %v of transformer init error %v", strTP, err)

--- a/transforms/ip/ip.go
+++ b/transforms/ip/ip.go
@@ -24,6 +24,7 @@ const (
 var (
 	_ transforms.StatsTransformer = &Transformer{}
 	_ transforms.Transformer      = &Transformer{}
+	_ transforms.Initializer      = &Transformer{}
 )
 
 type Transformer struct {
@@ -34,6 +35,15 @@ type Transformer struct {
 
 	loc   Locator
 	stats StatsInfo
+}
+
+func (t *Transformer) Init() error {
+	loc, err := NewLocator(t.DataPath)
+	if err != nil {
+		return fmt.Errorf("new locator: %v", err)
+	}
+	t.loc = loc
+	return nil
 }
 
 func (_ *Transformer) RawTransform(datas []string) ([]string, error) {

--- a/transforms/ip/ip_test.go
+++ b/transforms/ip/ip_test.go
@@ -1,6 +1,8 @@
 package ip
 
 import (
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +35,31 @@ func TestTransformer(t *testing.T) {
 	}
 	assert.Equal(t, expe, ipt.stats)
 	assert.Equal(t, ipt.Stage(), transforms.StageAfterParser)
+
+	// 并发查询测试
+	{
+		var wg sync.WaitGroup
+		for i := 1; i <= 100; i++ {
+			wg.Add(1)
+			go func() {
+				info, err := ipt.loc.Find("111.2.3.4")
+				assert.Nil(t, err)
+				exp := &LocationInfo{
+					Country:      "中国",
+					Region:       "浙江",
+					City:         "宁波",
+					Isp:          "N/A",
+					CountryCode:  "",
+					Latitude:     "",
+					Longitude:    "",
+					DistrictCode: "",
+				}
+				assert.Equal(t, exp, info)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	}
 
 	ipt2 := &Transformer{
 		Key:      "multi.ip",
@@ -141,6 +168,9 @@ func TestTransformer(t *testing.T) {
 	}
 	assert.Equal(t, expe4, ipt.stats)
 	assert.Equal(t, ipt4.Stage(), transforms.StageAfterParser)
+
+	// 确保多个 transformer 只有两个 Locator 产生
+	assert.Len(t, locatorStore.locators, 2)
 }
 
 func Test_badData(t *testing.T) {
@@ -163,4 +193,12 @@ func Test_badData(t *testing.T) {
 	ierr, ok = err.(ErrInvalidFile)
 	assert.True(t, ok)
 	assert.Equal(t, "datx", ierr.Format)
+
+	ipt = &Transformer{
+		Key:      "ip",
+		DataPath: "./test_data/bad.datn",
+	}
+	_, err = ipt.Transform([]Data{{"ip": "111.2.3.4"}, {"ip": "x.x.x.x"}})
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "unrecognized data file format"))
 }

--- a/transforms/ip/locator.go
+++ b/transforms/ip/locator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 const Null = "N/A"
@@ -19,6 +20,30 @@ func (e ErrInvalidFile) Error() string {
 	return fmt.Sprintf("invalid file format: %s - %s", e.Format, e.Reason)
 }
 
+// LocatorStore 按照文件路径保存了对应的 Locator，避免重复实例化浪费内存
+type LocatorStore struct {
+	lock     sync.RWMutex
+	locators map[string]Locator
+}
+
+// Get 返回对应路径的 Locator，如果 Locator 不存在则返回 nil
+func (s *LocatorStore) Get(fpath string) Locator {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.locators[fpath]
+}
+
+// Set 将 Locator 按照指定路径保存到 Store 中
+func (s *LocatorStore) Set(fpath string, loc Locator) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.locators[fpath] = loc
+}
+
+var locatorStore = &LocatorStore{
+	locators: make(map[string]Locator, 2), // 一般情况下最多就 dat 和 datx 相关的 Locator
+}
+
 // Locator represents an IP information loc.
 type Locator interface {
 	Find(string) (*LocationInfo, error)
@@ -26,12 +51,24 @@ type Locator interface {
 
 // NewLocator returns a new IP locator based on extension of given data file.
 func NewLocator(dataFile string) (Locator, error) {
-	switch {
-	case strings.HasSuffix(dataFile, ".dat"):
-		return newDatLocator(dataFile)
-	case strings.HasSuffix(dataFile, ".datx"):
-		return newDatxLocator(dataFile)
+	loc := locatorStore.Get(dataFile)
+	if loc != nil {
+		return loc, nil
 	}
 
-	return nil, errors.New("unrecognized data file format")
+	var err error
+	switch {
+	case strings.HasSuffix(dataFile, ".dat"):
+		loc, err = newDatLocator(dataFile)
+	case strings.HasSuffix(dataFile, ".datx"):
+		loc, err = newDatxLocator(dataFile)
+	default:
+		return nil, errors.New("unrecognized data file format")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	locatorStore.Set(dataFile, loc)
+	return loc, nil
 }

--- a/transforms/registry.go
+++ b/transforms/registry.go
@@ -40,8 +40,8 @@ type StatsTransformer interface {
 	SetStats(string) StatsInfo
 }
 
-//transformer初始化方法接口,err不为空表示初始化失败
-type Initialize interface {
+// transformer 初始化方法接口,err 不为空表示初始化失败
+type Initializer interface {
 	Init() error
 }
 

--- a/transforms/ua/ua.go
+++ b/transforms/ua/ua.go
@@ -19,6 +19,7 @@ const Name = "UserAgent"
 var (
 	_ transforms.StatsTransformer = &UATransformer{}
 	_ transforms.Transformer      = &UATransformer{}
+	_ transforms.Initializer      = &UATransformer{}
 )
 
 type UATransformer struct {


### PR DESCRIPTION
IP transformer 内部维护一个 store，确保一个文件路径只会产生一个 Locator，后续调用重复利用，并确保并发查询没有竞争