### PR TITLE
transforms/date: parse as local time when timezone info is missing

### DIFF
--- a/times/times.go
+++ b/times/times.go
@@ -101,7 +101,7 @@ func GetTimeZone() (zoneName, zoneValue string) {
 	return
 }
 
-func StrToTime(value string) (time.Time, error) {
+func StrToTimeLocation(value string, loc *time.Location) (time.Time, error) {
 	if value == "" {
 		return time.Now(), errors.New("empty time string")
 	}
@@ -109,10 +109,14 @@ func StrToTime(value string) (time.Time, error) {
 	var t time.Time
 	var err error
 	for _, layout := range layouts {
-		t, err = time.Parse(layout, value)
+		t, err = time.ParseInLocation(layout, value, loc)
 		if err == nil {
 			return t, nil
 		}
 	}
 	return time.Now(), fmt.Errorf("can not find any layout to parse %v", value)
+}
+
+func StrToTime(value string) (time.Time, error) {
+	return StrToTimeLocation(value, time.UTC)
 }

--- a/times/times_test.go
+++ b/times/times_test.go
@@ -41,7 +41,6 @@ func TestFormat(t *testing.T) {
 }
 
 func TestStrToTime(t *testing.T) {
-
 	zoneName, zoneValue := GetTimeZone()
 	if len(zoneValue) > 0 {
 		zoneValue += " " + zoneName
@@ -74,7 +73,41 @@ func TestStrToTime(t *testing.T) {
 			t.Error(err)
 		}
 		if !time.Equal(testCase.time) {
-			t.Errorf("(expected) %v != %v (actual)", time, testCase.time)
+			t.Errorf("(expected) %v != %v (actual)", testCase.time, time)
+		}
+	}
+}
+
+func TestStrToTimeLocal(t *testing.T) {
+	var testCases = []test{
+		{
+			time.Date(2012, 11, 22, 21, 28, 10, 0, time.Local),
+			"",
+			"2012-11-22 21:28:10",
+		},
+		{
+			time.Date(2012, 11, 22, 0, 0, 0, 0, time.Local),
+			"",
+			"2012/11/22",
+		},
+		{
+			time.Date(2012, 11, 22, 21, 28, 10, 0, time.Local),
+			"",
+			"2012-11-22 21:28:10",
+		},
+		{
+			time.Date(2016, 10, 20, 17, 20, 30, 600000000, time.Local),
+			"",
+			"2016/10/20 17:20:30.600000",
+		},
+	}
+	for _, testCase := range testCases {
+		time, err := StrToTimeLocation(testCase.strTime, time.Local)
+		if err != nil {
+			t.Error(err)
+		}
+		if !time.Equal(testCase.time) {
+			t.Errorf("(expected) %v != %v (actual)", testCase.time, time)
 		}
 	}
 }

--- a/transforms/date/date.go
+++ b/transforms/date/date.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/qiniu/logkit/transforms"
 	. "github.com/qiniu/logkit/utils/models"
+	"time"
 )
 
 var (
-	_ transforms.StatsTransformer = &DateTrans{}
-	_ transforms.Transformer      = &DateTrans{}
+	_ transforms.StatsTransformer = &Transformer{}
+	_ transforms.Transformer      = &Transformer{}
 )
 
-type DateTrans struct {
+type Transformer struct {
 	Key          string `json:"key"`
 	Offset       int    `json:"offset"`
 	LayoutBefore string `json:"time_layout_before"`
@@ -20,45 +21,45 @@ type DateTrans struct {
 	stats        StatsInfo
 }
 
-func (g *DateTrans) RawTransform(datas []string) ([]string, error) {
+func (t *Transformer) RawTransform(datas []string) ([]string, error) {
 	return datas, errors.New("date transformer not support rawTransform")
 }
 
-func (g *DateTrans) Transform(datas []Data) ([]Data, error) {
+func (t *Transformer) Transform(datas []Data) ([]Data, error) {
 	var err, fmtErr error
 	errNum := 0
-	keys := GetKeys(g.Key)
+	keys := GetKeys(t.Key)
 	for i := range datas {
 		val, getErr := GetMapValue(datas[i], keys...)
 		if getErr != nil {
-			errNum, err = transforms.SetError(errNum, getErr, transforms.GetErr, g.Key)
+			errNum, err = transforms.SetError(errNum, getErr, transforms.GetErr, t.Key)
 			continue
 		}
-		val, convertErr := ConvertDate(g.LayoutBefore, g.LayoutAfter, g.Offset, val)
+		val, convertErr := ConvertDate(t.LayoutBefore, t.LayoutAfter, t.Offset, time.Local, val)
 		if convertErr != nil {
 			errNum, err = transforms.SetError(errNum, convertErr, transforms.General, "")
 			continue
 		}
 		setErr := SetMapValue(datas[i], val, false, keys...)
 		if setErr != nil {
-			errNum, err = transforms.SetError(errNum, setErr, transforms.SetErr, g.Key)
+			errNum, err = transforms.SetError(errNum, setErr, transforms.SetErr, t.Key)
 		}
 	}
 
-	g.stats, fmtErr = transforms.SetStatsInfo(err, g.stats, int64(errNum), int64(len(datas)), g.Type())
+	t.stats, fmtErr = transforms.SetStatsInfo(err, t.stats, int64(errNum), int64(len(datas)), t.Type())
 	return datas, fmtErr
 }
 
-func (g *DateTrans) Description() string {
+func (t *Transformer) Description() string {
 	//return "transform string/long to specified date format"
 	return "将string/long数据转换成指定的时间格式, 如 1523878855 变为 2018-04-16T19:40:55+08:00"
 }
 
-func (g *DateTrans) Type() string {
+func (t *Transformer) Type() string {
 	return "date"
 }
 
-func (g *DateTrans) SampleConfig() string {
+func (t *Transformer) SampleConfig() string {
 	return `{
 		"type":"date",
 		"key":"DateFieldKey",
@@ -68,7 +69,7 @@ func (g *DateTrans) SampleConfig() string {
 	}`
 }
 
-func (it *DateTrans) ConfigOptions() []Option {
+func (t *Transformer) ConfigOptions() []Option {
 	return []Option{
 		transforms.KeyFieldName,
 		transforms.KeyTimezoneoffset,
@@ -91,21 +92,21 @@ func (it *DateTrans) ConfigOptions() []Option {
 	}
 }
 
-func (g *DateTrans) Stage() string {
+func (t *Transformer) Stage() string {
 	return transforms.StageAfterParser
 }
 
-func (g *DateTrans) Stats() StatsInfo {
-	return g.stats
+func (t *Transformer) Stats() StatsInfo {
+	return t.stats
 }
 
-func (g *DateTrans) SetStats(err string) StatsInfo {
-	g.stats.LastError = err
-	return g.stats
+func (t *Transformer) SetStats(err string) StatsInfo {
+	t.stats.LastError = err
+	return t.stats
 }
 
 func init() {
 	transforms.Add("date", func() transforms.Transformer {
-		return &DateTrans{}
+		return &Transformer{}
 	})
 }

--- a/transforms/date/date_test.go
+++ b/transforms/date/date_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/qiniu/logkit/transforms"
 	. "github.com/qiniu/logkit/utils/models"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestDateTransformer(t *testing.T) {
-	var k string = "k"
+func TestTransformer(t *testing.T) {
+	const k = "k"
 	nowstr := time.Now().Format("2006/01/02")
 	tm := time.Unix(1506049632, 0)
 	str3 := tm.Format("2006/01/02/03/04/05")
@@ -29,7 +29,7 @@ func TestDateTransformer(t *testing.T) {
 			LayoutBefore: "",
 			LayoutAfter:  "",
 			Key:          k,
-			data:         Data{k: "2017/03/28 15:41:53"},
+			data:         Data{k: "2017/03/28 15:41:53 -0000"},
 			exp:          Data{k: "2017-03-28T15:41:53Z"},
 		},
 		{
@@ -58,11 +58,73 @@ func TestDateTransformer(t *testing.T) {
 		},
 		{
 			Offset:       0,
+			LayoutBefore: "",
+			LayoutAfter:  "",
+			Key:          "a.b",
+			data:         Data{"a": map[string]interface{}{"b": "2017/03/28 15:41:53 -0000"}},
+			exp:          Data{"a": map[string]interface{}{"b": "2017-03-28T15:41:53Z"}},
+		},
+	}
+	for idx, ti := range tests {
+		tis := &Transformer{
+			Key:          ti.Key,
+			Offset:       ti.Offset,
+			LayoutBefore: ti.LayoutBefore,
+			LayoutAfter:  ti.LayoutAfter,
+		}
+		data, err := tis.Transform([]Data{ti.data})
+		assert.NoError(t, err)
+		exp := []Data{ti.exp}
+		assert.Equal(t, exp, data, fmt.Sprintf("idx %v", idx))
+		assert.Equal(t, transforms.StageAfterParser, tis.Stage())
+	}
+
+	fmt.Println(time.Now().Format(time.RFC3339), time.Now().Unix())
+}
+
+func TestTransformerLocal(t *testing.T) {
+	zoneValueRFC3339 := "Z"
+	_, offset := time.Now().Zone()
+	value := offset / 3600
+	if value > 0 {
+		zoneValueRFC3339 = fmt.Sprintf("+%02d:00", value)
+	} else if value < 0 {
+		zoneValueRFC3339 = fmt.Sprintf("-%02d:00", value)
+	}
+
+	const k = "k"
+	nowstr := time.Now().Format("2006/01/02")
+	tests := []struct {
+		Key          string
+		Offset       int
+		LayoutBefore string
+		LayoutAfter  string
+		data         Data
+		exp          Data
+	}{
+		{
+			Offset:       0,
+			LayoutBefore: "",
+			LayoutAfter:  "",
+			Key:          k,
+			data:         Data{k: "2017/03/28 15:41:53"},
+			exp:          Data{k: "2017-03-28T15:41:53" + zoneValueRFC3339},
+		},
+		{
+			Offset:       0,
+			LayoutBefore: "",
+			Key:          k,
+			LayoutAfter:  "2006/01/02",
+			data:         Data{k: nowstr},
+			exp:          Data{k: nowstr},
+		},
+		{
+			Offset:       0,
 			LayoutBefore: "2006/01/02/03/04/05",
 			LayoutAfter:  "",
 			Key:          k,
 			data:         Data{k: "2017/09/22/11/07/12"},
-			exp:          Data{k: "2017-09-22T11:07:12Z"},
+			exp:          Data{k: "2017-09-22T11:07:12" + zoneValueRFC3339},
 		},
 		{
 			Offset:       0,
@@ -70,7 +132,7 @@ func TestDateTransformer(t *testing.T) {
 			LayoutAfter:  "",
 			Key:          k,
 			data:         Data{k: "【2017/09/22/11/07/12】"},
-			exp:          Data{k: "2017-09-22T11:07:12Z"},
+			exp:          Data{k: "2017-09-22T11:07:12" + zoneValueRFC3339},
 		},
 		{
 			Offset:       0,
@@ -78,11 +140,11 @@ func TestDateTransformer(t *testing.T) {
 			LayoutAfter:  "",
 			Key:          "a.b",
 			data:         Data{"a": map[string]interface{}{"b": "2017/03/28 15:41:53"}},
-			exp:          Data{"a": map[string]interface{}{"b": "2017-03-28T15:41:53Z"}},
+			exp:          Data{"a": map[string]interface{}{"b": "2017-03-28T15:41:53" + zoneValueRFC3339}},
 		},
 	}
 	for idx, ti := range tests {
-		tis := &DateTrans{
+		tis := &Transformer{
 			Key:          ti.Key,
 			Offset:       ti.Offset,
 			LayoutBefore: ti.LayoutBefore,

--- a/transforms/mutate/convert.go
+++ b/transforms/mutate/convert.go
@@ -453,7 +453,7 @@ func dataConvert(data interface{}, schema DslSchemaEntry) (converted interface{}
 		case time.Time, *time.Time:
 			return value, nil
 		}
-		if converted, err = ConvertDate("", "", 0, data); err == nil {
+		if converted, err = ConvertDate("", "", 0, time.UTC, data); err == nil {
 			return converted, nil
 		}
 	case pipeline.PandoraTypeBool:

--- a/utils/models/utils.go
+++ b/utils/models/utils.go
@@ -657,7 +657,7 @@ func Bool2String(i bool) string {
 	return "false"
 }
 
-func ConvertDate(layoutBefore, layoutAfter string, offset int, v interface{}) (interface{}, error) {
+func ConvertDate(layoutBefore, layoutAfter string, offset int, loc *time.Location, v interface{}) (interface{}, error) {
 	var s int64
 	switch newv := v.(type) {
 	case int64:
@@ -674,13 +674,13 @@ func ConvertDate(layoutBefore, layoutAfter string, offset int, v interface{}) (i
 		s = int64(newv)
 	case string:
 		if layoutBefore != "" {
-			t, err := time.Parse(layoutBefore, newv)
+			t, err := time.ParseInLocation(layoutBefore, newv, loc)
 			if err != nil {
 				return v, fmt.Errorf("can not parse %v with layout %v", newv, layoutAfter)
 			}
 			return FormatWithUserOption(layoutAfter, offset, t), nil
 		}
-		t, err := times.StrToTime(newv)
+		t, err := times.StrToTimeLocation(newv, loc)
 		if err != nil {
 			return v, err
 		}

--- a/utils/models/utils_test.go
+++ b/utils/models/utils_test.go
@@ -478,21 +478,21 @@ func createTestFile(fileName string, content string) {
 }
 
 func Test_ConvertDate(t *testing.T) {
-	date, err := ConvertDate("", "", 0, 1525422699)
+	date, err := ConvertDate("", "", 0, time.UTC, 1525422699)
 	assert.NoError(t, err)
 	expect, err := getTimeStr(int64(1525422699))
 	assert.NoError(t, err)
 	assert.Equal(t, expect, date)
 
-	date, err = ConvertDate("", "", 0, "Feb 05 01:02:03")
+	date, err = ConvertDate("", "", 0, time.UTC, "Feb 05 01:02:03")
 	assert.NoError(t, err)
 	assert.Equal(t, "0000-02-05T01:02:03Z", date)
 
-	date, err = ConvertDate("", "", 0, "19/Aug/2000:14:47:37 -0400")
+	date, err = ConvertDate("", "", 0, time.UTC, "19/Aug/2000:14:47:37 -0400")
 	assert.NoError(t, err)
 	assert.Equal(t, "2000-08-19T14:47:37-04:00", date)
 
-	date, err = ConvertDate("20060102150405", "", 0, "20180204221045")
+	date, err = ConvertDate("20060102150405", "", 0, time.UTC, "20180204221045")
 	assert.NoError(t, err)
 	assert.Equal(t, "2018-02-04T22:10:45Z", date)
 }


### PR DESCRIPTION
当 date transformer 遇到没有时区信息的时间字符串时默认为本地时间（一般情况下，为 CST）