### PR TITLE
reader/{tailx,dirx}: clean expired submeta after sync

### DIFF
--- a/mgr/runner_test.go
+++ b/mgr/runner_test.go
@@ -1808,19 +1808,16 @@ func TestTailxCleaner(t *testing.T) {
 		log.Fatalf("TestTailxCleaner error mkdir %v %v", dir, err)
 	}
 	defer os.RemoveAll(dir)
-	defer os.RemoveAll(metaDir)
 
 	dira := filepath.Join(dir, "a")
 	os.MkdirAll(dira, DefaultDirPerm)
 	logPatha := filepath.Join(dira, "a.log")
-	err = ioutil.WriteFile(logPatha, []byte("a\n"), 0666)
-	assert.NoError(t, err)
+	assert.NoError(t, ioutil.WriteFile(logPatha, []byte("a\n"), 0666))
 
 	dirb := filepath.Join(dir, "b")
 	os.MkdirAll(dirb, DefaultDirPerm)
 	logPathb := filepath.Join(dirb, "b.log")
-	err = ioutil.WriteFile(logPathb, []byte("b\n"), 0666)
-	assert.NoError(t, err)
+	assert.NoError(t, ioutil.WriteFile(logPathb, []byte("b\n"), 0666))
 
 	readfile := filepath.Join(dir, "*", "*.log")
 	config := `
@@ -1855,8 +1852,7 @@ func TestTailxCleaner(t *testing.T) {
 }`
 
 	rc := RunnerConfig{}
-	err = jsoniter.Unmarshal([]byte(config), &rc)
-	assert.NoError(t, err)
+	assert.NoError(t, jsoniter.Unmarshal([]byte(config), &rc))
 	cleanChan := make(chan cleaner.CleanSignal)
 	rr, err := NewLogExportRunner(rc, cleanChan, reader.NewRegistry(), parser.NewRegistry(), sender.NewRegistry())
 	assert.NoError(t, err)
@@ -1866,34 +1862,31 @@ func TestTailxCleaner(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	logPatha1 := filepath.Join(dira, "a.log.1")
-	err = os.Rename(logPatha, logPatha1)
-	assert.NoError(t, err)
+	assert.NoError(t, os.Rename(logPatha, logPatha1))
 
-	err = ioutil.WriteFile(logPatha, []byte("bbbb\n"), 0666)
-	assert.NoError(t, err)
+	assert.NoError(t, ioutil.WriteFile(logPatha, []byte("bbbb\n"), 0666))
 
 	time.Sleep(5 * time.Second)
 
 	logPatha2 := filepath.Join(dira, "a.log.2")
-	err = os.Rename(logPatha, logPatha2)
-	assert.NoError(t, err)
+	assert.NoError(t, os.Rename(logPatha, logPatha2))
 
-	err = ioutil.WriteFile(logPatha, []byte("cccc\n"), 0666)
-	assert.NoError(t, err)
+	assert.NoError(t, ioutil.WriteFile(logPatha, []byte("cccc\n"), 0666))
 
 	time.Sleep(2 * time.Second)
 
 	assert.NotNil(t, rr.Cleaner())
-	var ret, dft int
 
+	var ret, dft int
+DONE:
 	for {
 		select {
 		case sig := <-cleanChan:
 			ret++
 			assert.Equal(t, "a.log.1", sig.Filename)
-			err = os.Remove(filepath.Join(sig.Logdir, sig.Filename))
-			assert.NoError(t, err)
+			assert.NoError(t, os.Remove(filepath.Join(sig.Logdir, sig.Filename)))
 			assert.Equal(t, reader.ModeTailx, sig.ReadMode)
+			break DONE
 		default:
 			dft++
 		}

--- a/reader/dirx/dir_reader.go
+++ b/reader/dirx/dir_reader.go
@@ -153,8 +153,12 @@ func HasDirExpired(dir string, expire time.Duration) bool {
 	var latestModTime time.Time
 	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			log.Errorf("Failed to walk directory file[%v]: %v", path, err)
+			log.Errorf("Failed to get directory entry[%v] info: %v", path, err)
 			return nil
+		} else if dir == path {
+			return nil
+		} else if info.IsDir() {
+			return filepath.SkipDir // 过滤子目录
 		}
 
 		if info.ModTime().After(latestModTime) {

--- a/reader/dirx/dirx_test.go
+++ b/reader/dirx/dirx_test.go
@@ -98,6 +98,9 @@ func multiReaderOneLineTest(t *testing.T) {
 	assert.NoError(t, dr.Start())
 	t.Log("Reader has started")
 
+	assert.Equal(t, 5*time.Second, dr.expire)
+	assert.Equal(t, 720*time.Hour, dr.submetaExpire)
+
 	maxNum := 0
 	emptyNum := 0
 	for {
@@ -121,7 +124,7 @@ func multiReaderOneLineTest(t *testing.T) {
 	// 确保上个 reader 已过期，新的 reader 已经探测到并创建成功
 	createDirWithName(dir2)
 	createFileWithContent(dir2file1, "hahaha\nhahaha\nhahaha\n")
-	time.Sleep(10 * time.Second)
+	time.Sleep(6 * time.Second)
 	assert.Equal(t, 1, dr.dirReaders.Num(), "Number of readers")
 	assert.Equal(t, "TestMultiReaderOneLine/logs/xyz", dr.dirReaders.getReaders()[0].originalPath)
 
@@ -190,6 +193,9 @@ func multiReaderMultiLineTest(t *testing.T) {
 	assert.NoError(t, dr.Start())
 	t.Log("Reader has started")
 
+	assert.Equal(t, 5*time.Second, dr.expire)
+	assert.Equal(t, 720*time.Hour, dr.submetaExpire)
+
 	maxNum := 0
 	emptyNum := 0
 	for {
@@ -213,7 +219,7 @@ func multiReaderMultiLineTest(t *testing.T) {
 	// 确保上个 reader 已过期，新的 reader 已经探测到并创建成功
 	createDirWithName(dir2)
 	createFileWithContent(dir2file1, "abc\nx\nabc\nx\nabc\nx\n")
-	time.Sleep(10 * time.Second)
+	time.Sleep(6 * time.Second)
 	assert.Equal(t, 1, dr.dirReaders.Num(), "Number of readers")
 	assert.Equal(t, "TestMultiReaderMultiLine/logs/xyz", dr.dirReaders.getReaders()[0].originalPath)
 
@@ -290,6 +296,9 @@ func multiReaderSyncMetaOneLineTest(t *testing.T) {
 	assert.NoError(t, dr.Start())
 	t.Log("Reader has started")
 
+	assert.Equal(t, 10*time.Second, dr.expire)
+	assert.Equal(t, 720*time.Hour, dr.submetaExpire)
+
 	maxNum := 0
 	emptyNum := 0
 	for {
@@ -341,7 +350,7 @@ func multiReaderSyncMetaOneLineTest(t *testing.T) {
 	// 确保上个 reader 已过期，新的 reader 已经探测到并创建成功
 	createDirWithName(dir2)
 	createFileWithContent(dir2file1, "ab1\nab2\nab3\n")
-	time.Sleep(15 * time.Second)
+	time.Sleep(11 * time.Second)
 	assert.Equal(t, 1, dr.dirReaders.Num(), "Number of readers")
 	assert.Equal(t, "TestMultiReaderSyncMetaOneLine/logs/xyz", dr.dirReaders.getReaders()[0].originalPath)
 
@@ -417,6 +426,9 @@ func multiReaderSyncMetaMutilineTest(t *testing.T) {
 	assert.NoError(t, dr.Start())
 	t.Log("Reader has started")
 
+	assert.Equal(t, 10*time.Second, dr.expire)
+	assert.Equal(t, 720*time.Hour, dr.submetaExpire)
+
 	maxNum := 0
 	emptyNum := 0
 	for {
@@ -469,7 +481,7 @@ func multiReaderSyncMetaMutilineTest(t *testing.T) {
 	// 确保上个 reader 已过期，新的 reader 已经探测到并创建成功
 	createDirWithName(dir2)
 	createFileWithContent(dir2file1, "abc\nx\nabc\ny\nabc\nz\n")
-	time.Sleep(15 * time.Second)
+	time.Sleep(11 * time.Second)
 	assert.Equal(t, 1, dr.dirReaders.Num(), "Number of readers")
 
 	t.Log("Reader has started to read two")
@@ -540,6 +552,9 @@ func TestMultiReaderReset(t *testing.T) {
 	dr := r.(*Reader)
 	assert.NoError(t, dr.Start())
 	t.Log("Reader has started")
+
+	assert.Equal(t, 0*time.Second, dr.expire)
+	assert.Equal(t, 720*time.Hour, dr.submetaExpire)
 
 	maxNum := 0
 	emptyNum := 0
@@ -637,6 +652,9 @@ func TestReaderErrBegin(t *testing.T) {
 	dr := r.(*Reader)
 	assert.NoError(t, dr.Start())
 	t.Log("Reader has started")
+
+	assert.Equal(t, 0*time.Second, dr.expire)
+	assert.Equal(t, 720*time.Hour, dr.submetaExpire)
 
 	maxNum := 0
 	for {

--- a/reader/meta_test.go
+++ b/reader/meta_test.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/qiniu/logkit/conf"
 	. "github.com/qiniu/logkit/reader/test"
+	"github.com/qiniu/logkit/utils"
 	. "github.com/qiniu/logkit/utils/models"
 )
 
@@ -244,4 +246,38 @@ func Test_GetLogFiles2(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestMeta_CleanExpiredSubMetas(t *testing.T) {
+	metaDir := "TestMeta_CleanExpiredSubMetas"
+	assert.NoError(t, os.Mkdir(metaDir, os.ModePerm))
+	defer os.RemoveAll(metaDir)
+
+	subMeta1Dir := filepath.Join(metaDir, "submeta1")
+	assert.NoError(t, os.Mkdir(subMeta1Dir, os.ModePerm))
+	subMeta1File := filepath.Join(subMeta1Dir, metaFileName)
+	assert.NoError(t, ioutil.WriteFile(subMeta1File, []byte("submeta1"), 0644))
+
+	subMeta2Dir := filepath.Join(metaDir, "submeta2")
+	assert.NoError(t, os.Mkdir(subMeta2Dir, os.ModePerm))
+	subMeta2File := filepath.Join(subMeta2Dir, metaFileName)
+	assert.NoError(t, ioutil.WriteFile(subMeta2File, []byte("submeta2"), 0644))
+
+	expired := time.Now().Add(-25 * time.Hour)
+	assert.NoError(t, os.Chtimes(subMeta2File, expired, expired))
+
+	m := &Meta{
+		Dir:            metaDir,
+		subMetaExpired: make(map[string]bool),
+	}
+	m.CheckExpiredSubMetas(time.Nanosecond)
+	m.CleanExpiredSubMetas(time.Nanosecond)
+
+	assert.True(t, utils.IsExist(subMeta1File))
+	assert.False(t, utils.IsExist(subMeta2File))
+
+	// 测试 submeta 清理缓存，subMeta1File 虽然过期但此刻不会被清理
+	assert.NoError(t, os.Chtimes(subMeta1File, expired, expired))
+	m.CleanExpiredSubMetas(time.Nanosecond)
+	assert.True(t, utils.IsExist(subMeta1File))
 }

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -81,9 +81,10 @@ const (
 	KeyIgnoreFileSuffix = "ignore_file_suffix"
 	KeyValidFilePattern = "valid_file_pattern"
 
-	KeyExpire       = "expire"
-	KeyMaxOpenFiles = "max_open_files"
-	KeyStatInterval = "stat_interval"
+	KeyExpire        = "expire"
+	KeySubmetaExpire = "submeta_expire"
+	KeyMaxOpenFiles  = "max_open_files"
+	KeyStatInterval  = "stat_interval"
 
 	KeyMysqlOffsetKey   = "mysql_offset_key"
 	KeyMysqlReadBatch   = "mysql_limit_batch"

--- a/reader/rest_reader_models.go
+++ b/reader/rest_reader_models.go
@@ -344,6 +344,16 @@ var (
 		Advance:      true,
 		ToolTip:      `针对dir读取模式需要解析的日志文件，可以设置读取的过程中忽略哪些文件后缀名，默认忽略的后缀包括".pid", ".swap", ".go", ".conf", ".tar.gz", ".tar", ".zip",".a", ".o", ".so"`,
 	}
+	OptionKeySubmetaExpire = Option{
+		KeyName:      KeySubmetaExpire,
+		ChooseOnly:   false,
+		Default:      "720h",
+		DefaultNoUse: false,
+		Required:     true,
+		Description:  "清理元数据的过期时间(submeta_expire)",
+		CheckRegex:   "\\d+[hms]",
+		ToolTip:      `当元数据的文件达到expire时间，则对其进行清理操作。写法为：数字加单位符号，组成字符串duration写法，支持时h、分m、秒s为单位，类似3h(3小时)，10m(10分钟)，5s(5秒)，默认的expire时间是720h，即30天。若最大过期时间(expire)为0s，则不会清理元数据`,
+	}
 	OptionKeyMaxOpenFiles = Option{
 		KeyName:      KeyMaxOpenFiles,
 		ChooseOnly:   false,
@@ -436,8 +446,9 @@ var ModeKeyOptions = map[string][]Option{
 			Required:     true,
 			Description:  "忽略文件的最大过期时间(expire)",
 			CheckRegex:   "\\d+[hms]",
-			ToolTip:      `当日志达到expire时间，则放弃追踪。写法为：数字加单位符号，组成字符串duration写法，支持时h、分m、秒s为单位，类似3h(3小时)，10m(10分钟)，5s(5秒)，默认的expire时间是24h`,
+			ToolTip:      `当日志达到expire时间，则放弃追踪。写法为：数字加单位符号，组成字符串duration写法，支持时h、分m、秒s为单位，类似3h(3小时)，10m(10分钟)，5s(5秒)，默认的expire时间是24h，当expire时间是0s时表示永不过期`,
 		},
+		OptionKeySubmetaExpire,
 		OptionKeyMaxOpenFiles,
 		OptionKeyStatInterval,
 	},
@@ -473,6 +484,7 @@ var ModeKeyOptions = map[string][]Option{
 			CheckRegex:   "\\d+[hms]",
 			ToolTip:      `当文件夹内所有的日志达到expire时间，则放弃追踪。写法为：数字加单位符号，组成字符串duration写法，支持时h、分m、秒s为单位，类似3h(3小时)，10m(10分钟)，5s(5秒)，默认的expire时间是0s，即永不过期`,
 		},
+		OptionKeySubmetaExpire,
 		OptionKeyMaxOpenFiles,
 		OptionKeyStatInterval,
 		OptionKeyValidFilePattern,

--- a/reader/tailx/tailx_test.go
+++ b/reader/tailx/tailx_test.go
@@ -122,7 +122,11 @@ func multiReaderOneLineTest(t *testing.T) {
 	mmr, err := NewReader(meta, c)
 	mr := mmr.(*Reader)
 	assert.NoError(t, mr.Start())
-	t.Log("mr started")
+	t.Log("Reader has started")
+
+	assert.Equal(t, 15*time.Second, mr.expire)
+	assert.Equal(t, 720*time.Hour, mr.submetaExpire)
+
 	go func() {
 		time.Sleep(15 * time.Second)
 		createFileWithContent(dir2file1, "hahaha\nhahaha\nhahaha\n")
@@ -217,7 +221,11 @@ func multiReaderMultiLineTest(t *testing.T) {
 	mmr.SetMode(reader.ReadModeHeadPatternString, "^abc*")
 	mr := mmr.(*Reader)
 	assert.NoError(t, mr.Start())
-	t.Log("mr started")
+	t.Log("Reader has started")
+
+	assert.Equal(t, 15*time.Second, mr.expire)
+	assert.Equal(t, 720*time.Hour, mr.submetaExpire)
+
 	go func() {
 		time.Sleep(15 * time.Second)
 		createFileWithContent(dir2file1, "abc\nx\nabc\nx\nabc\nx\n")
@@ -318,7 +326,11 @@ func multiReaderSyncMetaOneLineTest(t *testing.T) {
 	mmr, err := NewReader(meta, c)
 	mr := mmr.(*Reader)
 	assert.NoError(t, mr.Start())
-	t.Log("mr started")
+	t.Log("Reader has started")
+
+	assert.Equal(t, 15*time.Second, mr.expire)
+	assert.Equal(t, 720*time.Hour, mr.submetaExpire)
+
 	go func() {
 		time.Sleep(15 * time.Second)
 		createFileWithContent(dir2file1, "ab1\nab2\nab3\n")
@@ -448,7 +460,11 @@ func multiReaderSyncMetaMutilineTest(t *testing.T) {
 	mmr.SetMode(reader.ReadModeHeadPatternString, "^abc*")
 	mr := mmr.(*Reader)
 	assert.NoError(t, mr.Start())
-	t.Log("mr started")
+	t.Log("Reader has started")
+
+	assert.Equal(t, 15*time.Second, mr.expire)
+	assert.Equal(t, 720*time.Hour, mr.submetaExpire)
+
 	go func() {
 		time.Sleep(15 * time.Second)
 		createFileWithContent(dir2file1, "abc\nx\nabc\ny\nabc\nz\n")
@@ -568,7 +584,10 @@ func TestMultiReaderReset(t *testing.T) {
 	assert.NoError(t, err)
 	mr := mmr.(*Reader)
 	assert.NoError(t, mr.Start())
-	t.Log("mr started")
+	t.Log("Reader has started")
+
+	assert.Equal(t, 24*time.Hour, mr.expire)
+	assert.Equal(t, 720*time.Hour, mr.submetaExpire)
 
 	maxNum := 0
 	spaceNum := 0
@@ -627,7 +646,6 @@ func TestMultiReaderReset(t *testing.T) {
 }
 
 func TestReaderErrBegin(t *testing.T) {
-
 	dirName := "TestReaderErr"
 	dir := filepath.Join(dirName, "abc")
 	metaDir := filepath.Join(dirName, "meta")
@@ -685,7 +703,6 @@ func TestReaderErrBegin(t *testing.T) {
 }
 
 func TestReaderErrMiddle(t *testing.T) {
-
 	dirName := "TestReaderErr"
 	os.RemoveAll(dirName)
 	dir := filepath.Join(dirName, "abc")


### PR DESCRIPTION
JIRA: https://jira.qiniu.io/browse/PDR-7006

1. tailx 和 dirx 在每次 SyncMeta 后清理过期的 submeta 目录
2. 修复 dirx 检查过期时会扫到子目录的问题