### PR TITLE
pandora sender发送问题修复

### DIFF
--- a/mgr/runner.go
+++ b/mgr/runner.go
@@ -377,13 +377,6 @@ func (r *LogExportRunner) trySend(s sender.Sender, datas []Data, times int) bool
 				r.rsMutex.Lock()
 				r.rs.Lag.Ftlags = se.FtQueueLag
 				r.rsMutex.Unlock()
-			} else {
-				if cnt > 1 {
-					info.Errors -= se.Success
-				} else {
-					info.Errors += se.Errors
-				}
-				info.Success += se.Success
 			}
 		} else if err != nil {
 			if cnt <= 1 {
@@ -391,6 +384,9 @@ func (r *LogExportRunner) trySend(s sender.Sender, datas []Data, times int) bool
 			}
 		} else {
 			info.Success += int64(len(datas))
+			if cnt > 1 {
+				info.Errors -= int64(len(datas))
+			}
 		}
 		if err != nil {
 			info.LastError = TruncateStrSize(err.Error(), DefaultTruncateMaxSize)

--- a/sender/mock_pandora/mock_pandora.go
+++ b/sender/mock_pandora/mock_pandora.go
@@ -146,11 +146,19 @@ func (s *mock_pandora) PostRepos_Data() echo.HandlerFunc {
 		defer s.BodyMux.Unlock()
 		s.Body = strings.Join(sep, " ")
 
-		if len(strings.TrimSpace(strByte)) < 1 {
+		strByte = strings.TrimSpace(strByte)
+		if len(strByte) < 1 {
 			c.Response().Header().Set(ContentTypeHeader, ApplicationJson)
 			c.Response().WriteHeader(http.StatusNotFound)
 
 			return jsoniter.NewEncoder(c.Response()).Encode(map[string]string{"error": "E18006: empty entity"})
+		}
+
+		if strings.HasPrefix(strByte, "PointFailedSend") {
+			c.Response().Header().Set(ContentTypeHeader, ApplicationJson)
+			c.Response().WriteHeader(http.StatusNotFound)
+
+			return jsoniter.NewEncoder(c.Response()).Encode(errors.New("pandora send points error"))
 		}
 
 		if strings.Contains(s.Body, "E18111:") {

--- a/sender/pandora/pandora.go
+++ b/sender/pandora/pandora.go
@@ -833,6 +833,7 @@ func (s *Sender) generatePoint(data Data) (point Data) {
 			continue
 		}
 		point[k] = value
+		data[k] = value
 	}
 	if s.opt.uuid {
 		uuid, _ := gouuid.NewV4()

--- a/sender/pandora/pandora_test.go
+++ b/sender/pandora/pandora_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/qiniu/log"
+	"github.com/qiniu/pandora-go-sdk/base/reqerr"
 	"github.com/qiniu/pandora-go-sdk/pipeline"
 
 	"github.com/qiniu/logkit/conf"
@@ -950,4 +951,53 @@ func TestPandoraSenderTime(t *testing.T) {
 	}
 	resp = pandora.Body
 	assert.Equal(t, resp, "x1=123.2")
+}
+
+func TestErrPandoraSender(t *testing.T) {
+	_, pt := mockPandora.NewMockPandoraWithPrefix("/v2")
+	opt := &PandoraOption{
+		name:           "p_TestErrPandoraSender",
+		repoName:       "TestErrPandoraSender",
+		region:         "nb",
+		endpoint:       "http://127.0.0.1:" + pt,
+		ak:             "ak",
+		sk:             "sk",
+		schema:         "PointFailedSendx1",
+		autoCreate:     "PointFailedSendx1 s",
+		updateInterval: time.Second,
+		reqRateLimit:   0,
+		flowRateLimit:  0,
+		gzip:           false,
+		tokenLock:      new(sync.RWMutex),
+	}
+	s, err := newPandoraSender(opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d1 := Data{"x2": 1.2}
+	d2 := Data{}
+	d2["x3"] = 2
+	d2["x4"] = []float64{1.1, 2.2, 3.3}
+	d2["x5"] = map[string]interface{}{
+		"x6": 123,
+		"x7": map[string]interface{}{
+			"x8": []string{"abc"},
+			"x9": true,
+		},
+	}
+	d3 := Data{"PointFailedSendx1": "x1Val"}
+	err = s.Send([]Data{d1, d2, d3})
+	assert.Error(t, err)
+	st, ok := err.(*StatsError)
+	if !ok {
+		t.Errorf("expect StatsError, but got: %v", err)
+	}
+
+	sendError, ok := st.ErrorDetail.(*reqerr.SendError)
+	if !ok {
+		t.Errorf("expect SendError, but got: %v", err)
+	}
+	assert.Equal(t, []map[string]interface{}{{"PointFailedSendx1": "x1Val"}}, sendError.GetFailDatas())
+	assert.Equal(t, int64(1), st.Errors)
+	assert.Equal(t, int64(2), st.Success)
 }

--- a/sender/pandora/pandora_test.go
+++ b/sender/pandora/pandora_test.go
@@ -127,27 +127,27 @@ func TestPandoraSender(t *testing.T) {
 		t.Errorf("send data error exp %v but %v", exp, pandora.Body)
 	}
 	pandora.ChangeSchema([]pipeline.RepoSchemaEntry{
-		pipeline.RepoSchemaEntry{
+		{
 			Key:       "ab",
 			ValueType: "string",
 			Required:  true,
 		},
-		pipeline.RepoSchemaEntry{
+		{
 			Key:       "a1",
 			ValueType: "float",
 			Required:  true,
 		},
-		pipeline.RepoSchemaEntry{
+		{
 			Key:       "ac",
 			ValueType: "long",
 			Required:  true,
 		},
-		pipeline.RepoSchemaEntry{
+		{
 			Key:       "d",
 			ValueType: "date",
 			Required:  true,
 		},
-		pipeline.RepoSchemaEntry{
+		{
 			Key:       "ax",
 			ValueType: "string",
 			Required:  false,
@@ -1000,4 +1000,64 @@ func TestErrPandoraSender(t *testing.T) {
 	assert.Equal(t, []map[string]interface{}{{"PointFailedSendx1": "x1Val"}}, sendError.GetFailDatas())
 	assert.Equal(t, int64(1), st.Errors)
 	assert.Equal(t, int64(2), st.Success)
+}
+
+func TestAliasPandoraSender(t *testing.T) {
+	_, pt := mockPandora.NewMockPandoraWithPrefix("/v2")
+	opt := &PandoraOption{
+		name:           "p_TestErrPandoraSender",
+		repoName:       "TestErrPandoraSender",
+		region:         "nb",
+		endpoint:       "http://127.0.0.1:" + pt,
+		ak:             "ak",
+		sk:             "sk",
+		schema:         "x1 PointFailedSendx1",
+		autoCreate:     "PointFailedSendx1 s",
+		updateInterval: time.Second,
+		reqRateLimit:   0,
+		flowRateLimit:  0,
+		gzip:           false,
+		tokenLock:      new(sync.RWMutex),
+	}
+	s, err := newPandoraSender(opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataSlice := []struct {
+		data   Data
+		expect int
+	}{
+		{
+			Data{"x2": 1.2},
+			1,
+		},
+		{
+			Data{
+				"x3": 2,
+				"x4": []float64{1.1, 2.2, 3.3},
+				"x5": map[string]interface{}{
+					"x6": 123,
+					"x7": map[string]interface{}{
+						"x8": []string{"abc"},
+						"x9": true,
+					},
+				},
+			},
+			3,
+		},
+		{
+			Data{"x1": "x1Val"},
+			1,
+		},
+	}
+	var datas []Data
+	for _, d := range dataSlice {
+		datas = append(datas, d.data)
+	}
+	err = s.Send(datas)
+	assert.Error(t, err)
+	assert.Equal(t, 3, len(datas))
+	for idx, data := range datas {
+		assert.Equal(t, dataSlice[idx].expect, len(data))
+	}
 }


### PR DESCRIPTION
@wonderflow 

1. pandora sender发送数据成功/失败条数可能出错 
2. pandora sender有别名时，原始数据被删除，如果发送出错，下一次发送时会发送空数据