### PR TITLE
runner sender success/failed 数量修正

### DIFF
--- a/mgr/cluster_test.go
+++ b/mgr/cluster_test.go
@@ -46,7 +46,7 @@ type testCluParam struct {
 }
 
 func getClusterRunnerStatus(rn, lp, rs string, rdc, rds, pe, ps, se, ss int64, tag, url string) map[string]RunnerStatus {
-	runnerStatus := getRunnerStatus(rn, lp, rs, rdc, rds, pe, ps, se, ss)
+	runnerStatus := getRunnerStatus(rn, lp, rs, "file_sender", "", rdc, rds, pe, ps, se, ss)
 	for k, v := range runnerStatus {
 		v.Tag = tag
 		v.Url = url

--- a/sender/elasticsearch/elasticsearch.go
+++ b/sender/elasticsearch/elasticsearch.go
@@ -223,13 +223,21 @@ func (s *Sender) Send(datas []Data) error {
 		}
 		lastError, err := jsoniter.MarshalToString(lastFailedResult)
 		if err != nil {
-			lastError = fmt.Sprintf("%v", lastFailedResult)
+			lastError = fmt.Sprintf("marshal to string failed: %v", lastFailedResult)
 		}
-		return reqerr.NewSendError(
-			fmt.Sprintf("bulk failed with last error: %s", lastError),
-			failedDatas,
-			reqerr.TypeBinaryUnpack,
-		)
+
+		return &StatsError{
+			StatsInfo: StatsInfo{
+				Success:   int64(len(datas) - len(failedDatas)),
+				Errors:    int64(len(failedDatas)),
+				LastError: lastError,
+			},
+			ErrorDetail: reqerr.NewSendError(
+				fmt.Sprintf("bulk failed with last error: %s", lastError),
+				failedDatas,
+				reqerr.TypeBinaryUnpack,
+			),
+		}
 
 	case sender.ElasticVersion5:
 		bulkService := s.elasticV5Client.Bulk()
@@ -276,13 +284,20 @@ func (s *Sender) Send(datas []Data) error {
 		}
 		lastError, err := jsoniter.MarshalToString(lastFailedResult)
 		if err != nil {
-			lastError = fmt.Sprintf("%v", lastFailedResult)
+			lastError = fmt.Sprintf("marshal to string failed: %v", lastFailedResult)
 		}
-		return reqerr.NewSendError(
-			fmt.Sprintf("bulk failed with last error: %s", lastError),
-			failedDatas,
-			reqerr.TypeBinaryUnpack,
-		)
+		return &StatsError{
+			StatsInfo: StatsInfo{
+				Success:   int64(len(datas) - len(failedDatas)),
+				Errors:    int64(len(failedDatas)),
+				LastError: lastError,
+			},
+			ErrorDetail: reqerr.NewSendError(
+				fmt.Sprintf("bulk failed with last error: %s", lastError),
+				failedDatas,
+				reqerr.TypeBinaryUnpack,
+			),
+		}
 
 	default:
 		bulkService := s.elasticV3Client.Bulk()
@@ -329,13 +344,20 @@ func (s *Sender) Send(datas []Data) error {
 		}
 		lastError, err := jsoniter.MarshalToString(lastFailedResult)
 		if err != nil {
-			lastError = fmt.Sprintf("%v", lastFailedResult)
+			lastError = fmt.Sprintf("marshal to string failed: %v", lastFailedResult)
 		}
-		return reqerr.NewSendError(
-			fmt.Sprintf("bulk failed with last error: %s", lastError),
-			failedDatas,
-			reqerr.TypeBinaryUnpack,
-		)
+		return &StatsError{
+			StatsInfo: StatsInfo{
+				Success:   int64(len(datas) - len(failedDatas)),
+				Errors:    int64(len(failedDatas)),
+				LastError: lastError,
+			},
+			ErrorDetail: reqerr.NewSendError(
+				fmt.Sprintf("bulk failed with last error: %s", lastError),
+				failedDatas,
+				reqerr.TypeBinaryUnpack,
+			),
+		}
 	}
 	return nil
 }

--- a/sender/http/http.go
+++ b/sender/http/http.go
@@ -86,15 +86,15 @@ func (h *Sender) Send(data []Data) (err error) {
 	switch h.protocol {
 	case SendProtocalJson:
 		if sendBytes, err = h.convertToJsonBytes(data); err != nil {
-			return
+			return err
 		}
 	case SendProtocalCSV:
 		if sendBytes, err = h.convertToCsvBytes(data); err != nil {
-			return
+			return err
 		}
 	case SendProtocalWholeJson:
 		if sendBytes, err = jsoniter.Marshal(data); err != nil {
-			return
+			return err
 		}
 	default:
 		return fmt.Errorf("runner[%v] Sender[%v] send data error, protocol %v is not support", h.runnerName, h.Name(), h.protocol)

--- a/sender/influxdb/influxdb.go
+++ b/sender/influxdb/influxdb.go
@@ -200,19 +200,19 @@ func (s *Sender) sendPoints(ps Points) (err error) {
 	}
 	if err != nil {
 		log.Errorf("Runner[%s] %s request influxdb error: %v", s.runnerName, s.Name(), err)
-		return
+		return err
 	}
 
 	var b []byte
 	if b, err = ioutil.ReadAll(resp.Body); err != nil {
 		log.Errorf("Runner[%s] %s read resp body error: %v", s.runnerName, s.Name(), err)
-		return
+		return err
 	}
 	if resp.StatusCode != 204 {
-		err = fmt.Errorf(strings.Replace(string(b), "\\", "", -1))
-		return
+		return fmt.Errorf(strings.Replace(string(b), "\\", "", -1))
 	}
-	return
+
+	return nil
 }
 
 func (s *Sender) makePoint(d Data) (p Point, err error) {

--- a/sender/mock/mock.go
+++ b/sender/mock/mock.go
@@ -8,16 +8,18 @@ import (
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/sender"
 	. "github.com/qiniu/logkit/utils/models"
+	"github.com/qiniu/pandora-go-sdk/base/reqerr"
 )
 
 var _ sender.SkipDeepCopySender = &Sender{}
 
 // mock sender is used for debug
 type Sender struct {
-	name  string
-	Datas []Data
-	count int
-	mux   sync.Mutex
+	name     string
+	Datas    []Data
+	count    int
+	mux      sync.Mutex
+	isReqErr bool
 }
 
 func init() {
@@ -27,10 +29,12 @@ func init() {
 // NewMockSender 测试用sender
 func NewSender(c conf.MapConf) (sender.Sender, error) {
 	name, _ := c.GetStringOr(sender.KeyName, "mockSender")
+	isReqErr, _ := c.GetBoolOr("is_req_err", false)
 	ms := &Sender{
-		name:  name,
-		count: 0,
-		mux:   sync.Mutex{},
+		name:     name,
+		count:    0,
+		mux:      sync.Mutex{},
+		isReqErr: isReqErr,
 	}
 	return ms, nil
 }
@@ -39,6 +43,9 @@ func NewSender(c conf.MapConf) (sender.Sender, error) {
 func (mock *Sender) Name() string {
 	mock.mux.Lock()
 	defer mock.mux.Unlock()
+	if mock.isReqErr {
+		return mock.name
+	}
 	raw, err := jsoniter.Marshal(mock.Datas)
 	if err != nil {
 		raw = []byte(err.Error())
@@ -49,6 +56,20 @@ func (mock *Sender) Name() string {
 func (mock *Sender) Send(d []Data) error {
 	mock.mux.Lock()
 	defer mock.mux.Unlock()
+	if mock.isReqErr && len(d) > 0 {
+		failedDatas := sender.ConvertDatasBack([]Data{d[0]})
+		return &StatsError{
+			StatsInfo: StatsInfo{
+				Success: int64(len(d) - len(failedDatas)),
+				Errors:  int64(len(failedDatas)),
+			},
+			ErrorDetail: reqerr.NewSendError(
+				"mock failed",
+				failedDatas,
+				reqerr.TypeBinaryUnpack,
+			),
+		}
+	}
 	mock.Datas = append(mock.Datas, d...)
 	mock.count++
 	return nil

--- a/sender/pandora/pandora_test.go
+++ b/sender/pandora/pandora_test.go
@@ -285,10 +285,7 @@ func TestStatsSender(t *testing.T) {
 	d := Data{}
 	d["x1"] = "hh"
 	err = s.Send([]Data{d})
-	st, ok := err.(*StatsError)
-	assert.Equal(t, true, ok)
-	assert.NoError(t, st.ErrorDetail)
-	assert.Equal(t, st.Success, int64(1))
+	assert.NoError(t, err)
 	if !strings.Contains(pandora.Body, "x1=hh") {
 		t.Error("not x1 find error")
 	}


### PR DESCRIPTION
1. file/kafka/elasticsearch/pandora sender 返回的 err 进行修改，若有 err，返回的err类型为 StatsError，记录出错数据的数量，成功数量，最后一次出错消息，无 err，返回 nil
2. Kafka sender 中 last err 修改为 getEventMessage 和 其他错误的拼接
3. elasticsearch中的错误数量通过get failed data获得
4. runner中 send(fault_tolerant)错误数据修复，对返回的 err 进行修改，若有 err，返回的err类型为 StatsError，记录出错数据的数量，成功数量，最后一次出错消息，无 err，返回 nil
@wonderflow 