### PR TITLE
adjust statsError

### DIFF
--- a/conf/map_conf.go
+++ b/conf/map_conf.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -36,8 +37,8 @@ func ErrConfKeyType(key, dataType string) error {
 	return fmt.Errorf("TypeError: The configs must contains %s, dataType must be %s", key, dataType)
 }
 
-func ErrMissConfigAliasMap(detailKeys string) error {
-	return fmt.Errorf("AliasMapType must use format \"a b\" or \"a\",and split with \",\"")
+func ErrMissConfigAliasMap() error {
+	return errors.New("AliasMapType must use format \"a b\" or \"a\",and split with \",\"")
 }
 
 func (conf MapConf) Get(key string) (interface{}, error) {
@@ -222,7 +223,7 @@ func (conf MapConf) GetAliasMap(key string) (map[string]string, error) {
 		case 2:
 			name, alias = splits[0], splits[1]
 		default:
-			return newV, ErrMissConfigAliasMap(trimI)
+			return newV, ErrMissConfigAliasMap()
 		}
 		newV[name] = alias
 	}
@@ -290,7 +291,7 @@ func GetEnv(env string) string {
 func GetEnvValue(envName string) (string, error) {
 	envName = strings.TrimSpace(envName)
 	if envName == "" {
-		return "", fmt.Errorf("environment name is empty")
+		return "", errors.New("environment name is empty")
 	}
 	if osEnv := os.Getenv(envName); osEnv != "" {
 		return osEnv, nil

--- a/metric/system/processes.go
+++ b/metric/system/processes.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -88,7 +89,7 @@ func (p *Processes) Collect() (datas []map[string]interface{}, err error) {
 	// Collect windows process info
 	if runtime.GOOS == "windows" {
 		if err := p.getWinStat(fields); err != nil {
-			return nil, fmt.Errorf("collect windows processes error: %v", err.Error())
+			return nil, errors.New("collect windows processes error: " + err.Error())
 		}
 		return append(datas, fields), nil
 	}

--- a/mgr/api_parser.go
+++ b/mgr/api_parser.go
@@ -1,6 +1,7 @@
 package mgr
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -34,7 +35,7 @@ func (rs *RestService) PostParse() echo.HandlerFunc {
 		parseData, err := ParseData(parserConfig)
 		se, ok := err.(*StatsError)
 		if ok {
-			err = se.ErrorDetail
+			err = errors.New(se.LastError)
 		}
 		if err != nil {
 			errMsg := fmt.Sprintf("parser error %v", err)

--- a/mgr/metric_runner.go
+++ b/mgr/metric_runner.go
@@ -84,7 +84,7 @@ func NewMetricRunner(rc RunnerConfig, sr *sender.Registry) (runner *MetricRunner
 	collectors := make([]metric.Collector, 0)
 	transformers := make(map[string][]transforms.Transformer)
 	if len(rc.MetricConfig) == 0 {
-		return nil, fmt.Errorf("Runner " + rc.RunnerName + " has zero metric, ignore it")
+		return nil, errors.New("Runner " + rc.RunnerName + " has zero metric, ignore it")
 	}
 	for _, m := range rc.MetricConfig {
 		tp := m.MetricType
@@ -144,7 +144,7 @@ func NewMetricRunner(rc RunnerConfig, sr *sender.Registry) (runner *MetricRunner
 									trans = append(trans, DisTrans)
 								}
 							} else {
-								return nil, fmt.Errorf("http_datas need to be string")
+								return nil, errors.New("http_datas need to be string")
 							}
 						} else {
 							DisTrans, err := createDiscardTransformer(attr.Key)
@@ -328,7 +328,7 @@ func (r *MetricRunner) trySend(s sender.Sender, datas []Data, times int) bool {
 		}
 		err := s.Send(datas)
 		if se, ok := err.(*StatsError); ok {
-			err = se.ErrorDetail
+			err = se.SendError
 			if se.Ft {
 				r.rs.Lag.Ftlags = se.FtQueueLag
 			} else {

--- a/parser/csv/csv.go
+++ b/parser/csv/csv.go
@@ -526,7 +526,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 
 		if parseResult.Err != nil {
 			se.AddErrors()
-			se.ErrorDetail = parseResult.Err
+			se.LastError = parseResult.Err.Error()
 			errData := make(Data)
 			if !p.disableRecordErrData {
 				errData[KeyPandoraStash] = parseResult.Line
@@ -542,7 +542,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 			continue
 		}
 		if len(parseResult.Data) < 1 { //数据为空时不发送
-			se.ErrorDetail = fmt.Errorf("parsed no data by line [%v]", parseResult.Line)
+			se.LastError = fmt.Sprintf("parsed no data by line [%s]", parseResult.Line)
 			se.AddErrors()
 			continue
 		}
@@ -553,5 +553,8 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		datas = append(datas, parseResult.Data)
 	}
 
+	if se.Errors == 0 {
+		return datas, nil
+	}
 	return datas, se
 }

--- a/parser/csv/csv_test.go
+++ b/parser/csv/csv_test.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -63,7 +64,7 @@ func Test_Parser(t *testing.T) {
 	}
 	datas, err := p.Parse(lines)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.Error(t, err)
 
@@ -114,7 +115,7 @@ func Test_CsvParserForErrData(t *testing.T) {
 	}
 	datas, err := p.Parse(lines)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.Error(t, err)
 
@@ -157,7 +158,7 @@ func Test_CsvParserKeepRawData(t *testing.T) {
 	}
 	datas, err := p.Parse(lines)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{
@@ -204,7 +205,7 @@ func Test_Jsonmap(t *testing.T) {
 	}
 	datas, err := p.Parse(lines)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	if err != nil {
 		t.Error(err)
@@ -242,7 +243,7 @@ func Test_CsvParserLabel(t *testing.T) {
 	}
 	datas, err := p.Parse(lines)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.Error(t, err)
 	if len(datas) != 3 {
@@ -343,7 +344,7 @@ func TestRename(t *testing.T) {
 	}
 	gotDatas, err := p.Parse(lines)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	expDatas := []Data{
@@ -386,7 +387,7 @@ func TestRename(t *testing.T) {
 	assert.NoError(t, err)
 	gotDatas, err = p.Parse(lines)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	expDatas = []Data{
@@ -454,14 +455,14 @@ func TestAllMoreName(t *testing.T) {
 	assert.NoError(t, err)
 	datas, err := pp.Parse([]string{"a|b|c|d"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"ha0": "b", "logType": "a", "ha1": "c", "ha2": "d"}}, datas)
 
 	datas, err = pp.Parse([]string{"a"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"logType": "a"}}, datas)
@@ -478,28 +479,28 @@ func TestAllowLess(t *testing.T) {
 	assert.NoError(t, err)
 	datas, err := pp.Parse([]string{"a|1|1.2|d"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"a": int64(1), "logType": "a", "b": 1.2, "c": "d"}}, datas)
 
 	datas, err = pp.Parse([]string{"a|1|1.2|d|xx|yy"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"a": int64(1), "logType": "a", "b": 1.2, "c": "d", "ha0": "xx", "ha1": "yy"}}, datas)
 
 	datas, err = pp.Parse([]string{"a|1"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"a": int64(1), "logType": "a"}}, datas)
 
 	datas, err = pp.Parse([]string{"a|1.2|1.2|d"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.Error(t, err)
 }
@@ -516,14 +517,14 @@ func TestIgnoreField(t *testing.T) {
 	assert.NoError(t, err)
 	datas, err := pp.Parse([]string{"a|1.2|1.2|d"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"logType": "a", "b": 1.2, "c": "d"}}, datas)
 
 	datas, err = pp.Parse([]string{"a|1.2|1.2|d|xx"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.Error(t, err)
 }
@@ -539,14 +540,14 @@ func TestAllowNotMatch(t *testing.T) {
 	assert.NoError(t, err)
 	datas, err := pp.Parse([]string{"a|1|1.2|d|e"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"logType": "a", "a": int64(1), "b": 1.2, "c": "d"}}, datas)
 
 	datas, err = pp.Parse([]string{"a|1|1.2"})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"logType": "a", "a": int64(1), "b": 1.2}}, datas)
@@ -562,7 +563,7 @@ func TestCsvlastempty(t *testing.T) {
 	assert.NoError(t, err)
 	datas, err := pp.Parse([]string{"a\t1\t1.2\t "})
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, []Data{{"logType": "a", "a": int64(1), "b": 1.2, "c": " "}}, datas)

--- a/parser/grok/grok.go
+++ b/parser/grok/grok.go
@@ -234,7 +234,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 
 		if parseResult.Err != nil {
 			se.AddErrors()
-			se.ErrorDetail = parseResult.Err
+			se.LastError = parseResult.Err.Error()
 			errData := make(Data)
 			if !p.disableRecordErrData {
 				errData[KeyPandoraStash] = parseResult.Line
@@ -260,6 +260,9 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		datas = append(datas, parseResult.Data)
 	}
 
+	if se.Errors == 0 {
+		return datas, nil
+	}
 	return datas, se
 }
 

--- a/parser/grok/grok_test.go
+++ b/parser/grok/grok_test.go
@@ -115,9 +115,7 @@ func TestKeepRawData(t *testing.T) {
 	assert.NoError(t, p.compile())
 
 	m, err := p.Parse([]string{"142 bot"})
-	assert.Error(t, err)
-	require.NotNil(t, m)
-
+	assert.Nil(t, err)
 	assert.Equal(t, []Data{
 		{
 			"num":      int64(142),

--- a/parser/json/json.go
+++ b/parser/json/json.go
@@ -110,7 +110,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 
 		if parseResult.Err != nil {
 			se.AddErrors()
-			se.ErrorDetail = parseResult.Err
+			se.LastError = parseResult.Err.Error()
 			errData := make(Data)
 			if !p.disableRecordErrData {
 				errData[KeyPandoraStash] = parseResult.Line
@@ -126,7 +126,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 			continue
 		}
 		if len(parseResult.Datas) == 0 { //数据为空时不发送
-			se.ErrorDetail = fmt.Errorf("parsed no data by line [%v]", parseResult.Line)
+			se.LastError = fmt.Sprintf("parsed no data by line [%s]", parseResult.Line)
 			se.AddErrors()
 			continue
 		}
@@ -139,6 +139,9 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		datas = append(datas, parseResult.Datas...)
 	}
 
+	if se.Errors == 0 {
+		return datas, nil
+	}
 	return datas, se
 }
 

--- a/parser/json/json_test.go
+++ b/parser/json/json_test.go
@@ -95,8 +95,8 @@ func TestJsonParser(t *testing.T) {
 	m, err = p.Parse(tests[1].in)
 	if err != nil {
 		errx, _ := err.(*StatsError)
-		if errx.ErrorDetail != nil {
-			t.Error(errx.ErrorDetail)
+		if errx.LastError != "" {
+			t.Error(errx.LastError)
 		}
 	}
 	assert.EqualValues(t, tests[1].exp, m)
@@ -171,8 +171,8 @@ func TestJsonKeepRawData(t *testing.T) {
 	m, err = p.Parse(tests[1].in)
 	if err != nil {
 		errx, _ := err.(*StatsError)
-		if errx.ErrorDetail != nil {
-			t.Error(errx.ErrorDetail)
+		if errx.LastError != "" {
+			t.Error(errx.LastError)
 		}
 	}
 	assert.EqualValues(t, tests[1].exp, m)
@@ -380,9 +380,7 @@ func TestParseMutiLineJson(t *testing.T) {
 	p, _ := NewParser(c)
 	data := `[{"name":"ethancai", "fansCount": 9223372036854775807}]`
 	res, err := p.Parse([]string{data})
-	errx, _ := err.(*StatsError)
-	err = errx.ErrorDetail
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 
 	exp := []Data{{"name": "ethancai", "fansCount": json.Number("9223372036854775807")}}
 	assert.Equal(t, exp, res)
@@ -396,9 +394,7 @@ func TestParseSpaceJson(t *testing.T) {
 	p, _ := NewParser(c)
 	data := "\n"
 	res, err := p.Parse([]string{data})
-	errx, _ := err.(*StatsError)
-	err = errx.ErrorDetail
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 
 	exp := []Data{}
 	assert.Equal(t, exp, res)

--- a/parser/kafkarest/kafkarest.go
+++ b/parser/kafkarest/kafkarest.go
@@ -82,9 +82,13 @@ func (krp *Parser) Parse(lines []string) ([]Data, error) {
 			if !krp.disableRecordErrData || krp.keepRawData {
 				datas = append(datas, errData)
 			}
-			se.ErrorDetail = fmt.Errorf("kafka parser need data fields at least 3,acutal get %v", len(fields))
+			se.LastError = fmt.Sprintf("kafka parser need data fields at least 3, acutal get %d", len(fields))
 			se.AddErrors()
 		}
+	}
+
+	if se.Errors == 0 {
+		return datas, nil
 	}
 	return datas, se
 }

--- a/parser/logfmt/logfmt_test.go
+++ b/parser/logfmt/logfmt_test.go
@@ -1,6 +1,7 @@
 package logfmt
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -154,7 +155,7 @@ func TestParse(t *testing.T) {
 	for _, tt := range tests {
 		got, err := l.Parse(tt.s)
 		if c, ok := err.(*StatsError); ok {
-			err = c.ErrorDetail
+			err = errors.New(c.LastError)
 			assert.Equal(t, int64(0), c.Errors)
 		}
 

--- a/parser/mysql/mysql.go
+++ b/parser/mysql/mysql.go
@@ -86,7 +86,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		d, err := p.parse(line)
 		if err != nil {
 			se.AddErrors()
-			se.ErrorDetail = err
+			se.LastError = err.Error()
 			errData := make(Data)
 			if !p.disableRecordErrData {
 				errData[KeyPandoraStash] = line
@@ -106,6 +106,10 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		}
 		se.AddSuccess()
 		datas = append(datas, d)
+	}
+
+	if se.Errors == 0 {
+		return datas, nil
 	}
 	return datas, se
 }

--- a/parser/mysql/mysql_test.go
+++ b/parser/mysql/mysql_test.go
@@ -24,12 +24,7 @@ func TestMySqlLogParser1(t *testing.T) {
 	p, err := NewParser(nil)
 	assert.NoError(t, err)
 	datas, err := p.Parse(strings.Split(content, "\n"))
-	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
-		assert.Equal(t, "", st.LastError, st.LastError)
-		assert.Equal(t, int64(0), st.Errors)
-	}
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 
 	expectedEvent := Data{
 		"User":          "rdsadmin",
@@ -49,12 +44,7 @@ func TestMySqlKeepRawData(t *testing.T) {
 	p, err := NewParser(conf.MapConf{parser.KeyKeepRawData: "true"})
 	assert.NoError(t, err)
 	datas, err := p.Parse(strings.Split(content, "\n"))
-	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
-		assert.Equal(t, "", st.LastError, st.LastError)
-		assert.Equal(t, int64(0), st.Errors)
-	}
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 
 	expectedEvent := Data{
 		"User":            "rdsadmin",

--- a/parser/nginx/nginx.go
+++ b/parser/nginx/nginx.go
@@ -163,7 +163,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 
 		if parseResult.Err != nil {
 			se.AddErrors()
-			se.ErrorDetail = parseResult.Err
+			se.LastError = parseResult.Err.Error()
 			errData := make(Data)
 			if !p.disableRecordErrData {
 				errData[KeyPandoraStash] = parseResult.Line
@@ -179,7 +179,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 			continue
 		}
 		if len(parseResult.Data) < 1 { //数据为空时不发送
-			se.ErrorDetail = fmt.Errorf("parsed no data by line [%v]", parseResult.Line)
+			se.LastError = fmt.Sprintf("parsed no data by line [%v]", parseResult.Line)
 			se.AddErrors()
 			continue
 		}
@@ -191,6 +191,9 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		datas = append(datas, parseResult.Data)
 	}
 
+	if se.Errors == 0 {
+		return datas, nil
+	}
 	return datas, se
 }
 

--- a/parser/nginx/nginx_test.go
+++ b/parser/nginx/nginx_test.go
@@ -1,6 +1,7 @@
 package nginx
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -64,10 +65,7 @@ func TestNewNginxParser(t *testing.T) {
 	}
 	assert.Equal(t, p.Name(), "nginx", "nginx parser name not equal")
 	entry1S, err := p.Parse(accLog1)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-		assert.Equal(t, int64(0), c.Errors)
-	}
+	assert.Nil(t, err)
 	entry1 := entry1S[0]
 	for k, v := range entry1 {
 		assert.Equal(t, accLog1Entry[k], v, "parser "+k+" not match")
@@ -75,7 +73,7 @@ func TestNewNginxParser(t *testing.T) {
 	errFormat := fmt.Errorf("NginxParser fail to parse log line [%v], given format is [%v]", accErrLog[0], p.regexp)
 	_, err = p.Parse(accErrLog)
 	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
+		err = errors.New(c.LastError)
 	}
 	assert.Equal(t, err, errFormat, "it should be err format")
 
@@ -84,12 +82,7 @@ func TestNewNginxParser(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = p2.Parse(accLog2)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-	}
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 }
 
 func TestNewNginxParserForErrData(t *testing.T) {
@@ -100,10 +93,7 @@ func TestNewNginxParserForErrData(t *testing.T) {
 	}
 	assert.Equal(t, p.Name(), "nginx", "nginx parser name not equal")
 	entry1S, err := p.Parse(accLog1)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-		assert.Equal(t, int64(0), c.Errors)
-	}
+	assert.Nil(t, err)
 	if len(entry1S) != 1 {
 		t.Fatalf("parse lines error, expect 1 lines but got %v lines", len(entry1S))
 	}
@@ -122,11 +112,7 @@ func TestNginxParserKeepRawData(t *testing.T) {
 	}
 	assert.Equal(t, p.Name(), "nginx", "nginx parser name not equal")
 	entry1S, err := p.Parse(accLog1)
-
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-		assert.Equal(t, int64(0), c.Errors)
-	}
+	assert.Nil(t, err)
 	if len(entry1S) != 1 {
 		t.Fatalf("parse lines error, expect 1 lines but got %v lines", len(entry1S))
 	}
@@ -142,18 +128,13 @@ func TestNewNginxWithManuelRegex(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = p2.Parse(accLog2)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-	}
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 }
 
 func TestFindAllRegexpsFromConf(t *testing.T) {
 	confPath := "test_data/nginx.conf"
 	patterns, err := FindAllRegexpsFromConf(confPath)
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 
 	{
 		assert.NotNil(t, patterns["main"])

--- a/parser/qiniu/qiniu.go
+++ b/parser/qiniu/qiniu.go
@@ -361,7 +361,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		d, err := p.parse(line)
 		if err != nil {
 			se.AddErrors()
-			se.ErrorDetail = err
+			se.LastError = err.Error()
 			errData := make(Data)
 			if !p.disableRecordErrData {
 				errData[KeyPandoraStash] = line
@@ -381,6 +381,10 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 			d[parser.KeyRawData] = line
 		}
 		datas = append(datas, d)
+	}
+
+	if se.Errors == 0 {
+		return datas, nil
 	}
 	return datas, se
 }

--- a/parser/qiniu/qiniu_test.go
+++ b/parser/qiniu/qiniu_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/parser"
 	"github.com/qiniu/logkit/times"
-	. "github.com/qiniu/logkit/utils/models"
 )
 
 func Test_QiniuLogRegex(t *testing.T) {
@@ -108,7 +107,7 @@ func Test_QiniuLogRegex(t *testing.T) {
 	}
 	for _, ti := range tests2 {
 		got, err := regexp.MatchString("^"+PREFIX+" "+mp, ti.line)
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.Equal(t, ti.exp, got)
 	}
 }
@@ -121,9 +120,7 @@ func Test_QiniulogParser(t *testing.T) {
 	c[parser.KeyKeepRawData] = "true"
 	ps := parser.NewRegistry()
 	p, err := ps.NewLogParser(c)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 	lines := []string{
 		"2017/03/28 15:41:06 [Wm0AAPg-IUMW-68U][INFO] bdc.go:573: deleted: 67608",
 		`2016/10/20 17:30:21.433423 [GE2owHck-Y4IWJHS][WARN] github.com/qiniu/http/rpcutil.v1/rpc_util.go:203:  ==> qiniu.com/streaming.v2/apiserver.go:1367: E18102: The specified repo does not exist under the provided appid ~
@@ -133,10 +130,7 @@ func Test_QiniulogParser(t *testing.T) {
 		"",
 	}
 	dts, err := p.Parse(lines)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-		assert.Equal(t, int64(0), c.Errors)
-	}
+	assert.Nil(t, err)
 	if len(dts) != 4 {
 		t.Fatalf("parse lines error expect 4 but %v", len(dts))
 	}
@@ -167,12 +161,7 @@ func Test_QiniulogParser(t *testing.T) {
 		"2016/10/20 17:20:30.642662 [123][WARN] disk.go github.com/qiniu/logkit/queue/disk.go:241: 1",
 	}
 	dts, err = p.Parse(newlines)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-	}
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 	if len(dts) != 2 {
 		t.Fatalf("parse lines error expect 2 but %v", len(dts))
 	}
@@ -207,10 +196,7 @@ func Test_QiniulogParserForErrData(t *testing.T) {
 		"",
 	}
 	dts, err := p.Parse(lines)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-		assert.Equal(t, int64(0), c.Errors)
-	}
+	assert.Nil(t, err)
 	if len(dts) != 1 {
 		t.Fatalf("parse lines error, expect 1 but %v", len(dts))
 	}
@@ -227,9 +213,7 @@ func Test_QiniulogParserForTeapot(t *testing.T) {
 	c[parser.KeyLogHeaders] = "date,time,level,reqid,file"
 	ps := parser.NewRegistry()
 	p, err := ps.NewLogParser(c)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 
 	lines := []string{
 		`2017/01/22 11:16:08.885550 [INFO][2pyKMgVp5EKg-ZsU]["github.com/teapots/request-logger/logger.go:75"] [REQ_END] 200 0.010k 3.792ms
@@ -239,12 +223,7 @@ func Test_QiniulogParserForTeapot(t *testing.T) {
 	}
 
 	dts, err := p.Parse(lines)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-	}
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 
 	if len(dts) != 3 {
 		t.Fatalf("parse lines error expect 3 but %v", len(dts))
@@ -273,10 +252,7 @@ func Test_QiniulogParserForTeapot(t *testing.T) {
 	}
 
 	dts, err = p.Parse(newlines)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-	}
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, len(dts), 2)
 	assert.Equal(t, dts[0]["level"], "ERROR")
 	assert.Equal(t, dts[1]["level"], "WARN")
@@ -289,9 +265,7 @@ func Test_QiniulogParserForChange(t *testing.T) {
 	c[parser.KeyLogHeaders] = "date,time,reqid,level,file"
 	ps := parser.NewRegistry()
 	p, err := ps.NewLogParser(c)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 
 	lines := []string{
 		`2017/01/22 11:16:08.885550 [2pyKMgVp5EKg-ZsU][INFO]["github.com/teapots/request-logger/logger.go:75"] [REQ_END] 200 0.010k 3.792ms
@@ -301,12 +275,7 @@ func Test_QiniulogParserForChange(t *testing.T) {
 	}
 
 	dts, err := p.Parse(lines)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-	}
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 
 	if len(dts) != 3 {
 		t.Fatalf("parse lines error expect 3 but %v", len(dts))
@@ -335,10 +304,7 @@ func Test_QiniulogParserForChange(t *testing.T) {
 	}
 
 	dts, err = p.Parse(newlines)
-	if c, ok := err.(*StatsError); ok {
-		err = c.ErrorDetail
-	}
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, len(dts), 2)
 	assert.Equal(t, dts[0]["level"], "ERROR")
 	assert.Equal(t, dts[1]["level"], "WARN")

--- a/parser/raw/raw.go
+++ b/parser/raw/raw.go
@@ -46,7 +46,6 @@ func (p *Parser) Type() string {
 }
 
 func (p *Parser) Parse(lines []string) ([]Data, error) {
-
 	se := &StatsError{}
 	datas := []Data{}
 	for idx, line := range lines {
@@ -65,6 +64,10 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		}
 		datas = append(datas, d)
 		se.AddSuccess()
+	}
+
+	if se.Errors == 0 {
+		return datas, nil
 	}
 	return datas, se
 }

--- a/parser/raw/raw_test.go
+++ b/parser/raw/raw_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/parser"
-	. "github.com/qiniu/logkit/utils/models"
 )
 
 func Test_RawlogParser(t *testing.T) {
@@ -16,6 +15,7 @@ func Test_RawlogParser(t *testing.T) {
 	c[parser.KeyLabels] = "machine nb110"
 	c[parser.KeyDisableRecordErrData] = "true"
 	p, err := NewParser(c)
+	assert.Nil(t, err)
 	lines := []string{
 		"Oct 31 17:56:02 dell sudo:  boponik : TTY=pts/13 ; PWD=/home/boponik ; USER=root ; COMMAND=/bin/cat /var/log/auth.log",
 		`Oct 31 17:25:01 dell CRON[22418]: pam_unix(cron:session): session opened for user root by (uid=0)`,
@@ -24,14 +24,7 @@ func Test_RawlogParser(t *testing.T) {
 		"",
 	}
 	dts, err := p.Parse(lines)
-	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
-		assert.Equal(t, int64(0), st.Errors)
-	}
-	if err != nil {
-		t.Error(err)
-	}
-
+	assert.Nil(t, err)
 	if len(dts) != 4 {
 		t.Fatalf("parse lines error expect 4 lines but got %v lines", len(dts))
 	}
@@ -51,17 +44,13 @@ func Test_RawlogParserForErrData(t *testing.T) {
 	c[parser.KeyLabels] = "machine nb110"
 	c[parser.KeyDisableRecordErrData] = "false"
 	p, err := NewParser(c)
+	assert.Nil(t, err)
 	lines := []string{
 		"Oct 31 17:56:02 dell sudo:  boponik : TTY=pts/13 ; PWD=/home/boponik ; USER=root ; COMMAND=/bin/cat /var/log/auth.log",
 		"",
 	}
 	dts, err := p.Parse(lines)
-	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
-	}
-	if err != nil {
-		t.Error(err)
-	}
+	assert.Nil(t, err)
 
 	if len(dts) != 1 {
 		t.Fatalf("parse lines error, expect 1 lines but got %v lines", len(dts))

--- a/parser/syslog/syslog.go
+++ b/parser/syslog/syslog.go
@@ -150,7 +150,6 @@ func (p *SyslogParser) Parse(lines []string) ([]Data, error) {
 		d, err := p.parse(line)
 		if err != nil {
 			se.AddErrors()
-			se.ErrorDetail = err
 			se.LastError = err.Error()
 			if d != nil {
 				datas = append(datas, d)
@@ -171,6 +170,10 @@ func (p *SyslogParser) Parse(lines []string) ([]Data, error) {
 		}
 		datas = append(datas, d)
 		se.AddSuccess()
+	}
+
+	if se.Errors == 0 {
+		return datas, nil
 	}
 	return datas, se
 }

--- a/parser/syslog/syslog_test.go
+++ b/parser/syslog/syslog_test.go
@@ -42,6 +42,7 @@ func Test_SyslogParser(t *testing.T) {
 	c[parser.KeyLabels] = "machine nb110"
 	c[parser.KeyKeepRawData] = "true"
 	p, err := NewParser(c)
+	assert.Nil(t, err)
 	lines := []string{
 		`<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47`,
 		`- BOM'su root' failed for lonvick on /dev/pts/8`,
@@ -64,29 +65,17 @@ func Test_SyslogParser(t *testing.T) {
 		`- BOM'su root' failed for lonvick on /dev/pts/8`,
 	}
 	dts, err := p.Parse(lines)
+	assert.Nil(t, err)
 	indexes := []int{2, 3, 5, 9, 13, 15}
 	for i := range dts {
 		assert.Equal(t, lines[indexes[i]], dts[i][parser.KeyRawData])
-	}
-	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
-		assert.Equal(t, "", st.LastError, st.LastError)
-		assert.Equal(t, int64(0), st.Errors)
-	}
-	if err != nil {
-		t.Error(err)
 	}
 
 	if len(dts) != 6 {
 		t.Fatalf("parse lines error expect 6 lines but got %v lines", len(dts))
 	}
 	ndata, err := p.Parse([]string{parser.PandoraParseFlushSignal})
-	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
-		assert.Equal(t, "", st.LastError, st.LastError)
-		assert.Equal(t, int64(0), st.Errors)
-	}
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	dts = append(dts, ndata...)
 	for _, dt := range dts {
 		assert.Equal(t, "nb110", dt["machine"])
@@ -97,6 +86,7 @@ func Test_SyslogParserError(t *testing.T) {
 	c := conf.MapConf{}
 	c[parser.KeyParserType] = "syslog"
 	p, err := NewParser(c)
+	assert.Nil(t, err)
 	line := "Test my syslog CRON[000]: (root) CMD"
 	lines := []string{
 		line,
@@ -133,7 +123,7 @@ func TestSyslogParser_NoPanic(t *testing.T) {
 	c := conf.MapConf{}
 	c[parser.KeyParserType] = "syslog"
 	p, err := NewParser(c)
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	lines := []string{
 		`<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47`,
 		`- BOM'su root' failed for lonvick on /dev/pts/8`,
@@ -159,7 +149,7 @@ func TestSyslogParser_NoMatch(t *testing.T) {
 	c[parser.KeyParserType] = "syslog"
 	c[parser.KeySyslogMaxline] = "3"
 	p, err := NewParser(c)
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	lines := []string{
 		`003-10-11T22:14:15.003Z mymachine.example.com su - ID47`,
 		`BOM'su root' failed for lonvick on /dev/pts/8`,
@@ -171,7 +161,7 @@ func TestSyslogParser_NoMatch(t *testing.T) {
 	}
 	_, err = p.Parse(lines)
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = fmt.Errorf(st.LastError)
 	}
 	assert.Equal(t, errors.New("syslog meet max line 3, try to parse err No start char found for priority, check if this is standard rfc3164/rfc5424 syslog"), err)
 }

--- a/sender/elasticsearch/elasticsearch.go
+++ b/sender/elasticsearch/elasticsearch.go
@@ -232,7 +232,7 @@ func (s *Sender) Send(datas []Data) error {
 				Errors:    int64(len(failedDatas)),
 				LastError: lastError,
 			},
-			ErrorDetail: reqerr.NewSendError(
+			SendError: reqerr.NewSendError(
 				fmt.Sprintf("bulk failed with last error: %s", lastError),
 				failedDatas,
 				reqerr.TypeBinaryUnpack,
@@ -292,7 +292,7 @@ func (s *Sender) Send(datas []Data) error {
 				Errors:    int64(len(failedDatas)),
 				LastError: lastError,
 			},
-			ErrorDetail: reqerr.NewSendError(
+			SendError: reqerr.NewSendError(
 				fmt.Sprintf("bulk failed with last error: %s", lastError),
 				failedDatas,
 				reqerr.TypeBinaryUnpack,
@@ -352,7 +352,7 @@ func (s *Sender) Send(datas []Data) error {
 				Errors:    int64(len(failedDatas)),
 				LastError: lastError,
 			},
-			ErrorDetail: reqerr.NewSendError(
+			SendError: reqerr.NewSendError(
 				fmt.Sprintf("bulk failed with last error: %s", lastError),
 				failedDatas,
 				reqerr.TypeBinaryUnpack,

--- a/sender/fault_tolerant_test.go
+++ b/sender/fault_tolerant_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/qiniu/logkit/utils/models"
 	"github.com/qiniu/pandora-go-sdk/base/reqerr"
+
+	"github.com/qiniu/logkit/utils/models"
 )
 
 func Test_HandleStat(t *testing.T) {
@@ -38,22 +39,23 @@ func Test_HandleStat(t *testing.T) {
 	assert.Equal(t, int64(30), fs.stats.Errors)
 
 	se := &models.StatsError{
-		ErrorDetail: errors.New("i am detail"),
 		StatsInfo: models.StatsInfo{
-			Success: 100,
-			Errors:  20,
+			Success:   100,
+			Errors:    20,
+			LastError: "i am detail",
 		},
 	}
 
 	fs.stats.Errors = 0
 	fs.stats.Success = 0
-	err = fs.handleStat(se, false, 30)
-	assert.Equal(t, "i am detail", err.Error())
+	err = fs.handleStat(se, false, 130)
+	assert.Equal(t, "success 100 errors 20 last error i am detail, send error detail <nil>", err.Error())
 	assert.Equal(t, "i am detail", fs.stats.LastError)
-	assert.Equal(t, int64(20), fs.stats.Errors)
+	assert.Equal(t, int64(0), fs.stats.Success)
+	assert.Equal(t, int64(130), fs.stats.Errors)
 
 	se = &models.StatsError{
-		ErrorDetail: reqerr.NewSendError("senderror", nil, "no"),
+		SendError: reqerr.NewSendError("senderror", nil, "no"),
 		StatsInfo: models.StatsInfo{
 			Success: 100,
 			Errors:  20,
@@ -63,8 +65,7 @@ func Test_HandleStat(t *testing.T) {
 	fs.stats.Errors = 0
 	fs.stats.Success = 0
 	err = fs.handleStat(se, false, 30)
-	assert.Equal(t, "SendError: senderror, failDatas size : 0", err.Error())
+	assert.Equal(t, "success 100 errors 20 last error , send error detail SendError: senderror, failDatas size : 0", err.Error())
 	assert.Equal(t, "SendError: senderror, failDatas size : 0", fs.stats.LastError)
 	assert.Equal(t, int64(20), fs.stats.Errors)
-
 }

--- a/sender/file/file.go
+++ b/sender/file/file.go
@@ -116,7 +116,7 @@ func (s *Sender) Send(datas []Data) error {
 	for filename := range batchDatas {
 		bytes, err := s.marshalFunc(batchDatas[filename])
 		if err != nil {
-			ste.ErrorDetail = reqerr.NewSendError(
+			ste.SendError = reqerr.NewSendError(
 				fmt.Sprintf("%s marshal data failed: %v", s.Name(), err),
 				sender.ConvertDatasBack(datas),
 				reqerr.TypeDefault,
@@ -128,7 +128,7 @@ func (s *Sender) Send(datas []Data) error {
 
 		_, err = s.writers.Write(filename, bytes)
 		if err != nil {
-			ste.ErrorDetail = reqerr.NewSendError(
+			ste.SendError = reqerr.NewSendError(
 				fmt.Sprintf("%s write data to file failed: %v", s.Name(), err),
 				sender.ConvertDatasBack(datas),
 				reqerr.TypeDefault,

--- a/sender/mock/mock.go
+++ b/sender/mock/mock.go
@@ -63,7 +63,7 @@ func (mock *Sender) Send(d []Data) error {
 				Success: int64(len(d) - len(failedDatas)),
 				Errors:  int64(len(failedDatas)),
 			},
-			ErrorDetail: reqerr.NewSendError(
+			SendError: reqerr.NewSendError(
 				"mock failed",
 				failedDatas,
 				reqerr.TypeBinaryUnpack,

--- a/sender/mongodb/mongodb.go
+++ b/sender/mongodb/mongodb.go
@@ -138,7 +138,7 @@ func (s *Sender) Send(datas []Data) (se error) {
 		}
 	}
 	if len(failure) > 0 && lastErr != nil {
-		ss.ErrorDetail = reqerr.NewSendError("Write failure, last err is: "+lastErr.Error(), sender.ConvertDatasBack(failure), reqerr.TypeDefault)
+		ss.SendError = reqerr.NewSendError("Write failure, last err is: "+lastErr.Error(), sender.ConvertDatasBack(failure), reqerr.TypeDefault)
 	}
 	return ss
 }

--- a/sender/pandora/pandora_test.go
+++ b/sender/pandora/pandora_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/qiniu/log"
-	"github.com/qiniu/pandora-go-sdk/base/reqerr"
 	"github.com/qiniu/pandora-go-sdk/pipeline"
 
 	"github.com/qiniu/logkit/conf"
@@ -55,7 +54,7 @@ func TestPandoraSender(t *testing.T) {
 	d["d"] = 14773736325048765
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -80,7 +79,7 @@ func TestPandoraSender(t *testing.T) {
 	d = Data{"ab": "h1"}
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -94,7 +93,7 @@ func TestPandoraSender(t *testing.T) {
 	d["d"] = "2016/11/01 12:00:00.123456" + zoneValue
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -116,7 +115,7 @@ func TestPandoraSender(t *testing.T) {
 	}
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -163,7 +162,7 @@ func TestPandoraSender(t *testing.T) {
 	s.opt.updateInterval = 0
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -194,7 +193,7 @@ func TestPandoraSender(t *testing.T) {
 	s.opt.updateInterval = 0
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -237,7 +236,7 @@ func TestNestPandoraSender(t *testing.T) {
 	}
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -276,7 +275,7 @@ func TestUUIDPandoraSender(t *testing.T) {
 	d["x1"] = "hh"
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -629,7 +628,7 @@ func TestUpdatePandoraSchema(t *testing.T) {
 	d["x1"] = "hh"
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -641,7 +640,7 @@ func TestUpdatePandoraSchema(t *testing.T) {
 	d["x2"] = 2
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -666,7 +665,7 @@ func TestUpdatePandoraSchema(t *testing.T) {
 	d["x3"] = 2.1
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -714,7 +713,7 @@ func TestUpdatePandoraSchema(t *testing.T) {
 	d["x3"] = tm
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -734,7 +733,7 @@ func TestUpdatePandoraSchema(t *testing.T) {
 	d["x4"] = 1
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -837,7 +836,7 @@ func TestConvertDataPandoraSender(t *testing.T) {
 	d["x1"] = "123.2"
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -877,7 +876,7 @@ func TestPandoraSenderTime(t *testing.T) {
 	d["x1"] = "123.2"
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -910,7 +909,7 @@ func TestPandoraSenderTime(t *testing.T) {
 	d["x1"] = "123.2"
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -967,7 +966,7 @@ func TestPandoraSenderTime(t *testing.T) {
 	d["x1"] = "123.2"
 	err = s.Send([]Data{d})
 	if st, ok := err.(*StatsError); ok {
-		err = st.ErrorDetail
+		err = st.SendError
 	}
 	if err != nil {
 		t.Error(err)
@@ -1016,11 +1015,10 @@ func TestErrPandoraSender(t *testing.T) {
 		t.Errorf("expect StatsError, but got: %v", err)
 	}
 
-	sendError, ok := st.ErrorDetail.(*reqerr.SendError)
-	if !ok {
+	if st.SendError == nil {
 		t.Errorf("expect SendError, but got: %v", err)
 	}
-	assert.Equal(t, []map[string]interface{}{{"PointFailedSendx1": "x1Val"}}, sendError.GetFailDatas())
+	assert.Equal(t, []map[string]interface{}{{"PointFailedSendx1": "x1Val"}}, st.SendError.GetFailDatas())
 	assert.Equal(t, int64(1), st.Errors)
 	assert.Equal(t, int64(2), st.Success)
 }

--- a/utils/models/models.go
+++ b/utils/models/models.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/utils/equeue"
+	"github.com/qiniu/pandora-go-sdk/base/reqerr"
 )
 
 const (
@@ -115,9 +116,9 @@ type LagInfo struct {
 
 type StatsError struct {
 	StatsInfo
-	ErrorDetail         error `json:"error"`
-	Ft                  bool  `json:"-"`
-	FtNotRetry          bool  `json:"-"`
+	SendError           *reqerr.SendError `json:"error"`
+	Ft                  bool              `json:"-"`
+	FtNotRetry          bool              `json:"-"`
 	DatasourceSkipIndex []int
 	RemainDatas         []Data
 }
@@ -189,7 +190,7 @@ func (se *StatsError) Error() string {
 	if se == nil {
 		return ""
 	}
-	return fmt.Sprintf("success %v errors %v errordetail %v", se.Success, se.Errors, se.ErrorDetail)
+	return fmt.Sprintf("success %d errors %d last error %s, send error detail %v", se.Success, se.Errors, se.LastError, se.SendError)
 }
 
 func (se *StatsError) ErrorIndexIn(idx int) bool {

--- a/utils/models/utils.go
+++ b/utils/models/utils.go
@@ -184,10 +184,9 @@ func IsJsonString(s string) bool {
 }
 
 func ExtractField(slice []string) ([]string, error) {
-	var err error
 	switch len(slice) {
 	case 1:
-		return slice, err
+		return slice, nil
 	case 2:
 		rgexpr := "^%\\{\\[\\S+\\]}$" // --->  %{[type]}
 		r, _ := regexp.Compile(rgexpr)
@@ -196,12 +195,11 @@ func ExtractField(slice []string) ([]string, error) {
 		if bol {
 			rs := []rune(slice[0])
 			slice[0] = string(rs[3 : len(rs)-2])
-			return slice, err
+			return slice, nil
 		}
 	default:
 	}
-	err = fmt.Errorf("parameters error,  you can write two parameters like: %%{[type]}, default or only one: default")
-	return nil, err
+	return nil, errors.New("parameters error,  you can write two parameters like: %%{[type]}, default or only one: default")
 }
 
 func AddHttpProtocal(url string) string {
@@ -854,7 +852,7 @@ func CheckErr(err error) error {
 	var errorCnt int64
 	if ok {
 		errorCnt = se.Errors
-		err = se.ErrorDetail
+		err = errors.New(se.LastError)
 	} else {
 		errorCnt = 1
 	}

--- a/utils/models/utils_test.go
+++ b/utils/models/utils_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -1070,5 +1071,21 @@ func TestIsSubMetaExpireValid(t *testing.T) {
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.result, IsSubmetaExpireValid(test.submetaExpire, test.expire))
+	}
+}
+
+// 10000000	       148 ns/op	      64 B/op	       2 allocs/op
+func BenchmarkFmt(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		fmt.Errorf("test fmt errorf and errors.new with benchmark: %s", "my error")
+	}
+}
+
+// 2000000000	         0.87 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkErrors(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		errors.New("test fmt errorf and errors.new with benchmark: " + "my error")
 	}
 }


### PR DESCRIPTION
JIRA: https://jira.qiniu.io/browse/PDR-7639

 StatsError中目前ErrorDetail用法比较乱，目前有三种行为:
只是作为LastError(string)的error类型
有时候LastError是空， ErrorDetail有值，有时候ErrorDetail为空，LastError有值
记录SendError类型的错误

只有 ErrorDetail 为 SendError 类型时会做特殊处理
因此 将  ErrorDetail 变为  SendError，只记录  SendError 类型的错误，其他时候的错误统一记录到  LastError 中，如果没有错误，则返回 nil，不返回  StatsError 类型

@wonderflow 
@Unknwon 
@zoo4778362