### PR TITLE
fix kafka send error

### DIFF
--- a/sender/fault_tolerant.go
+++ b/sender/fault_tolerant.go
@@ -377,7 +377,7 @@ func (ft *FtSender) trySendDatas(datas []Data, failSleep int, isRetry bool) (bac
 	}
 
 	err = ft.handleStat(err, isRetry, dataLen)
-	if err == nil {
+	if empty := isErrorEmpty(err); empty {
 		return nil, nil
 	}
 
@@ -688,4 +688,20 @@ func SplitDataWithSplitSize(data string, splitSize int64) (valArray []string) {
 		valArray = append(valArray, string(dataConverse[end:]))
 	}
 	return valArray
+}
+
+func isErrorEmpty(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	se, succ := err.(*StatsError)
+	if !succ {
+		return false
+	}
+	if se.LastError == "" && se.SendError == nil {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Kafka 发送器，报错问题修复：
原因：不管是否有报错都会返回statsError结构，在handleSendError中默认返回 statsError 结构则一定有错
修复：Kafka 发送器中如果有错误（statsError.Error > 0），则返回statsError结构，否则返回 nil, handleSendError 之前增加判断 send error == nil && last error == "" 来 double check 是否真正有错
@wonderflow 
@zoo4778362 

fixes https://github.com/qiniu/logkit/issues/801