### PR TITLE
发送到文件时支持将数据划分到多个文件，并且支持写入原始数据字符串(“raw”字段的数据)

### DIFF
--- a/reader/dirx/dirx_test.go
+++ b/reader/dirx/dirx_test.go
@@ -575,21 +575,10 @@ func multiReaderNewestTest(t *testing.T) {
 	assert.EqualValues(t, 0, maxNum)
 	t.Log("Reader has finished reading one")
 
-	assert.NoError(t, dr.Close())
-	t.Log("Reader has closed")
-
-	r, err = NewReader(meta, c)
-	assert.NoError(t, err)
-
-	err = r.SetMode(ReadModeHeadPatternString, "^abc*")
-	assert.Nil(t, err)
-	dr = r.(*Reader)
-	assert.NoError(t, dr.Start())
 	emptyNum = 0
 	// 确保上个 reader 已过期，新的 reader 已经探测到并创建成功
 	createDirWithName(dir2)
 	createFileWithContent(dir2file1, "abc\nx\nabc\ny\nabc\nz\n")
-	time.Sleep(10 * time.Second)
 	assert.Equal(t, 1, dr.dirReaders.Num(), "Number of readers")
 
 	t.Log("Reader has started to read two")

--- a/sender/config/config.go
+++ b/sender/config/config.go
@@ -173,6 +173,26 @@ var ModeKeyOptions = map[string][]Option{
 			Description:  "时间戳键名(file_send_timestamp_key)",
 			ToolTip:      `用于获取时间的时间戳键名，如果该键存在则将替代当前时间渲染路径中的魔法变量，格式必须是 RFC3339Nano`,
 		},
+		{
+			KeyName:       KeyFileWriteRaw,
+			ChooseOnly:    true,
+			ChooseOptions: []interface{}{"false", "true"},
+			Default:       "false",
+			Required:      false,
+			Advance:       true,
+			DefaultNoUse:  true,
+			Description:   "原始raw字段写入(file_write_raw)",
+			ToolTip:       `直接写入Data中的raw字段`,
+		},
+		{
+			KeyName:      KeyFilePartition,
+			Default:      "4",
+			Required:     false,
+			Advance:      true,
+			DefaultNoUse: true,
+			Description:  "文件Partition切分数量(file_partition)",
+			ToolTip:      `文件Partition切分可以指定路径写入`,
+		},
 	},
 	TypePandora: {
 		{

--- a/sender/config/models.go
+++ b/sender/config/models.go
@@ -161,6 +161,8 @@ const (
 	KeyFileSenderPath         = "file_send_path"
 	KeyFileSenderTimestampKey = "file_send_timestamp_key"
 	KeyFileSenderMaxOpenFiles = "file_send_max_open_files"
+	KeyFileWriteRaw           = "file_write_raw"
+	KeyFilePartition          = "file_partition"
 
 	// http
 	KeyHttpSenderUrl      = "http_sender_url"

--- a/sender/file/file.go
+++ b/sender/file/file.go
@@ -1,14 +1,18 @@
 package file
 
 import (
+	"bytes"
 	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/json-iterator/go"
 	"github.com/lestrrat-go/strftime"
 
-	"github.com/qiniu/pandora-go-sdk/base/reqerr"
-
+	"github.com/qiniu/log"
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/sender"
 	. "github.com/qiniu/logkit/sender/config"
@@ -26,6 +30,8 @@ type Sender struct {
 	timestampKey string
 	marshalFunc  func([]Data) ([]byte, error)
 	writers      *writerStore
+
+	partition int
 }
 
 func init() {
@@ -61,6 +67,26 @@ func jsonMarshalWithNewLineFunc(datas []Data) ([]byte, error) {
 	return append(bytes, '\n'), nil
 }
 
+func writeRawFunc(datas []Data) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, d := range datas {
+		raw := d["raw"]
+		switch bts := raw.(type) {
+		case string:
+			buf.Write([]byte(bts))
+			if !strings.HasSuffix(bts, "\n") {
+				buf.Write([]byte("\n"))
+			}
+		case []byte:
+			buf.Write(bts)
+			if !strings.HasSuffix(string(bts), "\n") {
+				buf.Write([]byte("\n"))
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}
+
 func NewSender(conf conf.MapConf) (sender.Sender, error) {
 	path, err := conf.GetString(KeyFileSenderPath)
 	if err != nil {
@@ -69,10 +95,17 @@ func NewSender(conf conf.MapConf) (sender.Sender, error) {
 	name, _ := conf.GetStringOr(KeyName, "fileSender:"+path)
 	timestampKey, _ := conf.GetStringOr(KeyFileSenderTimestampKey, "")
 	maxOpenFile, _ := conf.GetIntOr(KeyFileSenderMaxOpenFiles, defaultFileWriterPoolSize)
-	s, err := newSender(name, path, timestampKey, maxOpenFile, jsonMarshalWithNewLineFunc)
+	rawMarshal, _ := conf.GetBoolOr(KeyFileWriteRaw, false)
+	partition, _ := conf.GetIntOr(KeyFilePartition, 0)
+	marshal := jsonMarshalWithNewLineFunc
+	if rawMarshal {
+		marshal = writeRawFunc
+	}
+	s, err := newSender(name, path, timestampKey, maxOpenFile, marshal)
 	if err != nil {
 		return nil, err
 	}
+	s.partition = partition
 	return s, nil
 }
 
@@ -93,7 +126,17 @@ func (s *Sender) Send(datas []Data) error {
 
 	// 如果没有设置 timestamp key 则直接赋值
 	if len(s.timestampKey) == 0 {
-		batchDatas[nowStr] = datas
+		if s.partition <= 1 {
+			batchDatas[nowStr] = datas
+		} else {
+			for i := 0; i < s.partition; i++ {
+				batchDatas[getPartitionFolder(nowStr, i)] = make([]Data, 0)
+			}
+			for i, v := range datas {
+				str := getPartitionFolder(nowStr, i%s.partition)
+				batchDatas[str] = append(batchDatas[str], v)
+			}
+		}
 	} else {
 		var tStr string
 		for i := range datas {
@@ -114,37 +157,39 @@ func (s *Sender) Send(datas []Data) error {
 	}
 
 	// 分批写入不同文件
-	for filename := range batchDatas {
-		bytes, err := s.marshalFunc(batchDatas[filename])
-		if err != nil {
-			ste.SendError = reqerr.NewSendError(
-				fmt.Sprintf("%s marshal data failed: %v", s.Name(), err),
-				sender.ConvertDatasBack(datas),
-				reqerr.TypeDefault,
-			)
-			ste.LastError = err.Error()
-			ste.Errors += int64(len(batchDatas[filename]))
-			return ste
-		}
-
-		_, err = s.writers.Write(filename, bytes)
-		if err != nil {
-			ste.SendError = reqerr.NewSendError(
-				fmt.Sprintf("%s write data to file failed: %v", s.Name(), err),
-				sender.ConvertDatasBack(datas),
-				reqerr.TypeDefault,
-			)
-			ste.LastError = err.Error()
-			ste.Errors += int64(len(batchDatas[filename]))
-			return ste
-		}
+	wg := &sync.WaitGroup{}
+	for filename, datas := range batchDatas {
+		wg.Add(1)
+		go s.writeFile(filename, datas, wg)
 	}
+	wg.Wait()
+
 	if ste.Errors > 0 {
 		return ste
 	}
 	return nil
 }
 
+func (s *Sender) writeFile(filename string, datas []Data, wg *sync.WaitGroup) {
+	defer wg.Done()
+	datasBytes, err := s.marshalFunc(datas)
+	if err != nil {
+		log.Errorf("get datas bytes to file[%s] failed: %v, datas length: %d", filename, err, len(datas))
+		return
+	}
+	_, err = s.writers.Write(filename, datasBytes)
+	if err != nil {
+		log.Errorf("write to file[%s] failed: %v, datas length: %d", filename, err, len(datas))
+		return
+	}
+}
+
 func (s *Sender) Close() error {
 	return s.writers.Close()
+}
+
+func getPartitionFolder(nowStr string, idx int) string {
+	base := filepath.Base(nowStr)
+	dir := filepath.Dir(nowStr)
+	return filepath.Join(dir, "partition"+strconv.Itoa(idx), base)
 }


### PR DESCRIPTION
基本就是pr: https://github.com/qiniu/logkit/pull/831 中的内容，
变化： 1. 将增加的两个选项放在高级配置中 2. partition <= 0 改为 partition <= 1
@wonderflow 