### PR TITLE
1. tailx修改，提升性能，2. 修复stop/start重启之后没有记录is_stopped状态

### DIFF
--- a/mgr/dataflow_test.go
+++ b/mgr/dataflow_test.go
@@ -255,7 +255,6 @@ func Test_ParseData(t *testing.T) {
 }
 
 func Test_TransformData(t *testing.T) {
-	t.Parallel()
 	config1 := `{
 			"type":"IP",
 			"key":  "ip",
@@ -329,7 +328,6 @@ func Test_getDataFromTransformConfig(t *testing.T) {
 }
 
 func Test_getTransformer(t *testing.T) {
-	t.Parallel()
 	config1 := `{
 			"type":"IP",
 			"key":  "ip",

--- a/mgr/mgr.go
+++ b/mgr/mgr.go
@@ -854,6 +854,7 @@ func (m *Manager) StopRunner(name string) (err error) {
 	if err != nil {
 		return err
 	}
+	conf.IsStopped = true
 
 	if err = m.backupRunnerConfig(filename, conf); err != nil {
 		// 备份配置文件失败，回滚
@@ -983,7 +984,7 @@ func (m *Manager) startRunner(filename string, conf RunnerConfig) (err error) {
 	return nil
 }
 
-func (m *Manager) stopRunner(filename string, conf RunnerConfig) (err error) {
+func (m *Manager) stopRunner(filename string, conf RunnerConfig) error {
 	if conf.IsStopped == true {
 		return fmt.Errorf("runner %v has already stopped", filename)
 	}
@@ -992,7 +993,7 @@ func (m *Manager) stopRunner(filename string, conf RunnerConfig) (err error) {
 		m.setRunnerConfig(filename, conf)
 		return nil
 	}
-	if err = m.RemoveWithConfig(filename, false); err != nil {
+	if err := m.RemoveWithConfig(filename, false); err != nil {
 		return fmt.Errorf("remove runner %v error %v", filename, err)
 	}
 	m.setRunnerConfig(filename, conf)

--- a/mgr/mgr.go
+++ b/mgr/mgr.go
@@ -816,6 +816,7 @@ func (m *Manager) StartRunner(name string) (err error) {
 	if err = m.startRunner(filename, conf); err != nil {
 		return err
 	}
+	conf.IsStopped = false
 
 	if err = m.backupRunnerConfig(filename, conf); err != nil {
 		// 备份配置文件失败，回滚
@@ -972,12 +973,12 @@ func (m *Manager) GetRunnerNames() []string {
 	return runnerNames
 }
 
-func (m *Manager) startRunner(filename string, conf RunnerConfig) (err error) {
+func (m *Manager) startRunner(filename string, conf RunnerConfig) error {
 	if conf.IsStopped == false {
 		return fmt.Errorf("runner %v has already started", filename)
 	}
 	conf.IsStopped = false
-	if err = m.ForkRunner(filename, conf, true); err != nil {
+	if err := m.ForkRunner(filename, conf, true); err != nil {
 		return fmt.Errorf("forkRunner %v error %v", filename, err)
 	}
 

--- a/reader/meta.go
+++ b/reader/meta.go
@@ -40,7 +40,7 @@ const (
 	metaFormat          = "%s\t%d\n"
 	tableDoneFormat     = "%s\n"
 	bufMetaFormat       = "read:%d\nwrite:%d\nbufsize:%d\n"
-	defaultIOLimit      = 20 //默认读取速度为20MB/s
+	defaultIOLimit      = -1 // 默认不限速，之前默认读取速度为20MB/s
 	ModeMetrics         = "metrics"
 )
 

--- a/reader/seqfile.go
+++ b/reader/seqfile.go
@@ -228,7 +228,13 @@ func (sf *SeqFile) Close() (err error) {
 	if sf.f == nil {
 		return
 	}
-	return sf.f.Close()
+
+	err = sf.f.Close()
+	if err != nil && err == os.ErrClosed {
+		return err
+	}
+
+	return nil
 }
 
 // 这个函数目前只针对stale NFS file handle的情况，重新打开文件

--- a/reader/seqfile.go
+++ b/reader/seqfile.go
@@ -141,7 +141,11 @@ func NewSeqFile(meta *Meta, path string, ignoreHidden, newFileNewLine bool, suff
 			return nil, err
 		}
 		sf.f = f
-		sf.ratereader = rateio.NewRateReader(f, meta.Readlimit)
+		if meta.Readlimit > 0 {
+			sf.ratereader = rateio.NewRateReader(f, meta.Readlimit)
+		} else {
+			sf.ratereader = f
+		}
 		sf.offset = offset
 	} else {
 		sf.inode = 0
@@ -249,7 +253,11 @@ func (sf *SeqFile) reopenForESTALE() error {
 	if sf.ratereader != nil {
 		sf.ratereader.Close()
 	}
-	sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	if sf.meta.Readlimit > 0 {
+		sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	} else {
+		sf.ratereader = f
+	}
 	ninode, err := utilsos.GetIdentifyIDByFile(f)
 	if err != nil {
 		//为了不影响程序运行
@@ -499,7 +507,11 @@ func (sf *SeqFile) newOpen() (err error) {
 	if sf.ratereader != nil {
 		sf.ratereader.Close()
 	}
-	sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	if sf.meta.Readlimit > 0 {
+		sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	} else {
+		sf.ratereader = f
+	}
 	sf.f = f
 	sf.offset = 0
 	sf.inode, err = utilsos.GetIdentifyIDByPath(sf.currFile)
@@ -536,7 +548,11 @@ func (sf *SeqFile) open(fi os.FileInfo) (err error) {
 	if sf.ratereader != nil {
 		sf.ratereader.Close()
 	}
-	sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	if sf.meta.Readlimit > 0 {
+		sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	} else {
+		sf.ratereader = f
+	}
 	sf.offset = 0
 	sf.inode, err = utilsos.GetIdentifyIDByPath(sf.currFile)
 	if err != nil {

--- a/reader/singlefile.go
+++ b/reader/singlefile.go
@@ -189,7 +189,10 @@ func (sf *SingleFile) Close() (err error) {
 		sf.ratereader.Close()
 	}
 	if sf.f != nil {
-		return sf.f.Close()
+		err = sf.f.Close()
+		if err != nil && err != os.ErrClosed {
+			return err
+		}
 	}
 	return nil
 }

--- a/reader/singlefile.go
+++ b/reader/singlefile.go
@@ -92,8 +92,13 @@ func NewSingleFile(meta *Meta, path, whence string, errDirectReturn bool) (sf *S
 		originpath: originpath,
 		pfi:        pfi,
 		f:          f,
-		ratereader: rateio.NewRateReader(f, meta.Readlimit),
 		mux:        sync.Mutex{},
+	}
+
+	if meta.Readlimit > 0 {
+		sf.ratereader = rateio.NewRateReader(f, meta.Readlimit)
+	} else {
+		sf.ratereader = f
 	}
 
 	// 如果meta初始信息损坏

--- a/reader/singlefile.go
+++ b/reader/singlefile.go
@@ -252,7 +252,11 @@ func (sf *SingleFile) Reopen() (err error) {
 	if sf.ratereader != nil {
 		sf.ratereader.Close()
 	}
-	sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	if sf.meta.Readlimit > 0 {
+		sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	} else {
+		sf.ratereader = f
+	}
 	sf.offset = 0
 	return
 }
@@ -278,7 +282,11 @@ func (sf *SingleFile) reopenForESTALE() (err error) {
 	if sf.ratereader != nil {
 		sf.ratereader.Close()
 	}
-	sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	if sf.meta.Readlimit > 0 {
+		sf.ratereader = rateio.NewRateReader(f, sf.meta.Readlimit)
+	} else {
+		sf.ratereader = f
+	}
 	return
 }
 

--- a/reader/tailx/tailx.go
+++ b/reader/tailx/tailx.go
@@ -128,6 +128,62 @@ func NewActiveReader(originPath, realPath, whence string, notFirstTime bool, met
 
 }
 
+func (ar *ActiveReader) Start() {
+	if atomic.LoadInt32(&ar.status) == StatusRunning {
+		log.Warnf("Runner[%v] ActiveReader %s was already running", ar.runnerName, ar.originpath)
+		return
+	}
+
+	if atomic.LoadInt32(&ar.status) == StatusStopping {
+		cnt := 0
+		// 等待结束
+		for atomic.LoadInt32(&ar.status) != StatusStopped {
+			cnt++
+			//超过300个10ms，即3s，就强行退出
+			if cnt > 300 {
+				log.Errorf("Runner[%v] ActiveReader %s was not closed after 3s, force closing it", ar.runnerName, ar.originpath)
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		atomic.CompareAndSwapInt32(&ar.status, StatusStopping, StatusStopped)
+		log.Warnf("Runner[%v] ActiveReader %s was stopped", ar.runnerName, ar.originpath)
+	}
+
+	atomic.StoreInt32(&ar.status, StatusInit)
+
+	go ar.Run()
+}
+
+func (ar *ActiveReader) Stop() error {
+	if atomic.LoadInt32(&ar.status) == StatusStopped {
+		return nil
+	}
+
+	if !atomic.CompareAndSwapInt32(&ar.status, StatusRunning, StatusStopping) &&
+		atomic.LoadInt32(&ar.status) != StatusStopping {
+		err := fmt.Errorf("Runner[%v] ActiveReader %s was not in StatusRunning or StatusStopping status, exit it... ", ar.runnerName, ar.originpath)
+		log.Debug(err)
+		return err
+	} else {
+		log.Warnf("Runner[%v] ActiveReader %s was closing", ar.runnerName, ar.originpath)
+	}
+
+	cnt := 0
+	// 等待结束
+	for atomic.LoadInt32(&ar.status) != StatusStopped {
+		cnt++
+		//超过3个1s，即3s，就强行退出
+		if cnt > 3 {
+			log.Errorf("Runner[%v] ActiveReader %s was not closed after 3s, force closing it", ar.runnerName, ar.originpath)
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	return nil
+}
+
 func (ar *ActiveReader) Run() {
 	if !atomic.CompareAndSwapInt32(&ar.status, StatusInit, StatusRunning) {
 		log.Errorf("Runner[%v] ActiveReader %s was not in StatusInit before Running,exit it...", ar.runnerName, ar.originpath)
@@ -147,24 +203,27 @@ func (ar *ActiveReader) Run() {
 			ar.readcache, err = ar.br.ReadLine()
 			ar.cacheLineMux.Unlock()
 			if err != nil && err != io.EOF && err != os.ErrClosed {
-				log.Warnf("Runner[%v] ActiveReader %s read error: %v", ar.runnerName, ar.originpath, err)
+				log.Warnf("Runner[%v] ActiveReader %s read error: %v, stop it", ar.runnerName, ar.originpath, err)
 				ar.setStatsError(err.Error())
 				ar.sendError(err)
-				time.Sleep(2 * time.Second)
-				continue
+				ar.Stop()
+				return
 			}
 			if ar.readcache == "" {
 				ar.emptyLineCnt++
 				//文件EOF，同时没有任何内容，代表不是第一次EOF，休息时间设置长一些
 				if err == io.EOF {
 					atomic.StoreInt32(&ar.inactive, 1)
-					log.Debugf("Runner[%v] %v meet EOF, ActiveReader was inactive now, sleep 5 seconds", ar.runnerName, ar.originpath)
-					time.Sleep(5 * time.Second)
-					continue
+					log.Debugf("Runner[%v] %v meet EOF, ActiveReader was inactive now, stop it", ar.runnerName, ar.originpath)
+					ar.Stop()
+					return
 				}
-				// 一小时没读到内容，设置为inactive
-				if ar.emptyLineCnt > 60*60 {
+				// 3s 没读到内容，设置为inactive
+				if ar.emptyLineCnt > 3 {
 					atomic.StoreInt32(&ar.inactive, 1)
+					log.Debugf("Runner[%v] %v meet EOF, ActiveReader was inactive now, stop it", ar.runnerName, ar.originpath)
+					ar.Stop()
+					return
 				}
 				//读取的结果为空，无论如何都sleep 1s
 				time.Sleep(time.Second)
@@ -202,25 +261,11 @@ func (ar *ActiveReader) Run() {
 }
 func (ar *ActiveReader) Close() error {
 	defer log.Warnf("Runner[%v] ActiveReader %s was closed", ar.runnerName, ar.originpath)
-	err := ar.br.Close()
-	if atomic.CompareAndSwapInt32(&ar.status, StatusRunning, StatusStopping) {
-		log.Warnf("Runner[%v] ActiveReader %s was closing", ar.runnerName, ar.originpath)
-	} else {
-		return err
+	brCloseErr := ar.br.Close()
+	if err := ar.Stop(); err != nil {
+		return brCloseErr
 	}
-
-	cnt := 0
-	// 等待结束
-	for atomic.LoadInt32(&ar.status) != StatusStopped {
-		cnt++
-		//超过300个10ms，即3s，就强行退出
-		if cnt > 300 {
-			log.Errorf("Runner[%v] ActiveReader %s was not closed after 3s, force closing it", ar.runnerName, ar.originpath)
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return err
+	return nil
 }
 
 func (ar *ActiveReader) setStatsError(err string) {
@@ -432,6 +477,7 @@ func (r *Reader) statLogPath() {
 		log.Debugf("Runner[%v] statLogPath %v find matches: %v", r.meta.RunnerName, r.logPathPattern, strings.Join(matches, ", "))
 	}
 	var newaddsPath []string
+	now := time.Now()
 	for _, mc := range matches {
 		rp, fi, err := GetRealPath(mc)
 		if err != nil {
@@ -443,9 +489,12 @@ func (r *Reader) statLogPath() {
 			continue
 		}
 		r.armapmux.Lock()
-		_, ok := r.fileReaders[rp]
+		filear, ok := r.fileReaders[rp]
 		r.armapmux.Unlock()
 		if ok {
+			if IsFileModified(rp, r.statInterval, now) {
+				filear.Start()
+			}
 			log.Debugf("Runner[%v] <%v> is collecting, ignore...", r.meta.RunnerName, rp)
 			continue
 		}
@@ -486,7 +535,7 @@ func (r *Reader) statLogPath() {
 		}
 		r.armapmux.Unlock()
 		if !r.hasStopped() && !r.isStopping() {
-			go ar.Run()
+			ar.Start()
 		} else {
 			log.Warnf("Runner[%v] %v NewActiveReader but reader was stopped, will not running...", r.meta.RunnerName, mc)
 		}

--- a/reader/tailx/tailx.go
+++ b/reader/tailx/tailx.go
@@ -135,6 +135,7 @@ func (ar *ActiveReader) Run() {
 	}
 	var err error
 	timer := time.NewTicker(time.Second)
+	defer timer.Stop()
 	for {
 		if atomic.LoadInt32(&ar.status) == StatusStopped || atomic.LoadInt32(&ar.status) == StatusStopping {
 			atomic.CompareAndSwapInt32(&ar.status, StatusStopping, StatusStopped)

--- a/utils/models/models_test.go
+++ b/utils/models/models_test.go
@@ -1,10 +1,15 @@
 package models
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/qiniu/log"
 )
 
 func Test_KeyValueSlice(t *testing.T) {
@@ -79,4 +84,37 @@ func Test_KeyValueSlice(t *testing.T) {
 	}
 	sort.Stable(testData.origin)
 	assert.Equal(t, testData.expect, testData.origin)
+}
+
+func TestIsFileModified(t *testing.T) {
+	dirname := "TestIsFileModified"
+	createDirWithName(dirname)
+	defer os.RemoveAll(dirname)
+	filename := filepath.Join(dirname, "file1.log")
+	createFileWithContent(filename, "abc123\nabc123\nabc123\nabc123\nabc123\n")
+	actual := IsFileModified(filename, 3*time.Minute, time.Now())
+	assert.True(t, actual)
+
+	err := os.Chtimes(filename, time.Now().Add(-10*time.Minute), time.Now().Add(-10*time.Minute))
+	assert.Nil(t, err)
+	actual = IsFileModified(filename, 3*time.Minute, time.Now())
+	assert.False(t, actual)
+}
+
+func createFileWithContent(filePath, content string) {
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, DefaultFilePerm)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	file.WriteString(content)
+	file.Close()
+}
+
+func createDirWithName(dir string) {
+	err := os.Mkdir(dir, DefaultDirPerm)
+	if err != nil {
+		log.Error(err)
+		return
+	}
 }

--- a/utils/models/utils.go
+++ b/utils/models/utils.go
@@ -954,3 +954,19 @@ func GetGrokLabels(labelList []string, nameMap map[string]struct{}) (labels []Gr
 	}
 	return
 }
+
+func IsFileModified(path string, interval time.Duration, compare time.Time) bool {
+	modTime := time.Now()
+	fi, err := os.Stat(path)
+	if err != nil {
+		log.Warnf("Failed to get config modtime: %v", err)
+	} else {
+		modTime = fi.ModTime()
+	}
+
+	if modTime.Add(interval).Before(compare) {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
@wonderflow 
1. rateReader 不填时，默认值为-1（<=0时）不限速
2. tailx读不到数据（超过3s）或者读到文件结尾（eof），停止读取，下一个扫描周期如果修改时间在扫描间隔内，则开始读取，扫描周期内出现新文件，判断是否超过expire加入内存进行读取
3. 修复 stop/start 收集器时，没有记录到文件，导致重启logkit后收集器全部启动