### PR TITLE
fix cloudtrail reader with gzipped data checked

### DIFF
--- a/mgr/runner_test.go
+++ b/mgr/runner_test.go
@@ -1998,7 +1998,7 @@ DONE:
 
 		}
 		time.Sleep(50 * time.Millisecond)
-		if dft > 100 {
+		if dft > 200 {
 			break
 		}
 	}


### PR DESCRIPTION
cloudtrail的包在读取的过程中可能会读到gzip的二进制流，直接写文件会导致乱码，需要检验下头部bytes，然后对gzip的情况解压缩