### PR TITLE
logkit s3 和 cloudtrail 元数据目录生成逻辑不依赖ak/sk #713

### DIFF
--- a/mgr/runner.go
+++ b/mgr/runner.go
@@ -231,11 +231,13 @@ func NewLogExportRunner(rc RunnerConfig, cleanChan chan<- cleaner.CleanSignal, r
 	mode := rc.ReaderConfig["mode"]
 	if mode == ModeCloudTrail || mode == ModeCloudTrailV2 {
 		syncDir := rc.ReaderConfig[KeySyncDirectory]
+		oldSyncDir := syncDir
 		if syncDir == "" {
 			bucket, prefix, region, ak, sk, _ := cloudtrail.GetS3UserInfo(rc.ReaderConfig)
-			syncDir = cloudtrail.GetDefaultSyncDir(bucket, prefix, region, ak, sk, rc.RunnerName)
+			oldSyncDir, syncDir = cloudtrail.GetDefaultSyncDir(bucket, prefix, region, ak, sk, rc.RunnerName)
 		}
 		rc.ReaderConfig[KeyLogPath] = syncDir
+		rc.ReaderConfig[KeyLogPathOld] = oldSyncDir
 		if len(rc.CleanerConfig) == 0 {
 			rc.CleanerConfig = conf.MapConf{
 				"delete_enable":       "true",

--- a/reader/cloudtrail/cloudtrail_test.go
+++ b/reader/cloudtrail/cloudtrail_test.go
@@ -1,0 +1,61 @@
+package cloudtrail
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bmizerany/assert"
+
+	"github.com/qiniu/log"
+
+	"github.com/qiniu/logkit/utils"
+	. "github.com/qiniu/logkit/utils/models"
+)
+
+func TestGetDefaultSyncDir(t *testing.T) {
+	bucket := "bucket1"
+	prefix := "prefix1"
+	region := "region1"
+	ak := "ak1"
+	sk := "sk1"
+	runnerName := "runner1"
+	createDirWithName("s3data")
+	origDir := filepath.Join("s3data", "data"+Hash(ak+sk+region+bucket+prefix+runnerName))
+	createDirWithName(origDir)
+	_, newDir := GetDefaultSyncDir(bucket, prefix, region, ak, sk, runnerName)
+	os.RemoveAll(newDir)
+	isOrigDirExist := utils.IsExist(origDir)
+	assert.Equal(t, false, isOrigDirExist)
+}
+
+func TestGetDefaultMetaStore(t *testing.T) {
+	bucket := "bucket1"
+	prefix := "prefix1"
+	region := "region1"
+	ak := "ak1"
+	sk := "sk1"
+	runnerName := "runner1"
+	origMeta := ".metastore" + Hash(ak+sk+region+bucket+prefix+runnerName)
+	createFileWithContent(origMeta, "test")
+	newMeta := GetDefaultMetaStore(bucket, prefix, region, ak, sk, runnerName)
+	os.RemoveAll(newMeta)
+	isOrigMetaExist := utils.IsExist(origMeta)
+	assert.Equal(t, false, isOrigMetaExist)
+}
+
+func createDirWithName(dirx string) {
+	if err := os.Mkdir(dirx, DefaultDirPerm); err != nil {
+		log.Error(err)
+	}
+}
+
+func createFileWithContent(filepathn, lines string) {
+	file, err := os.OpenFile(filepathn, os.O_CREATE|os.O_WRONLY, DefaultFilePerm)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	file.WriteString(lines)
+	file.Close()
+}

--- a/reader/cloudtrail/cloudtrail_test.go
+++ b/reader/cloudtrail/cloudtrail_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/qiniu/log"
 

--- a/reader/config/models.go
+++ b/reader/config/models.go
@@ -11,6 +11,7 @@ const (
 	KeyAuthPassword = "auth_password"
 
 	KeyLogPath           = "log_path"
+	KeyLogPathOld        = "log_path_old"
 	KeyMetaPath          = "meta_path"
 	KeyFileDone          = "file_done"
 	KeyMode              = "mode"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,6 +36,14 @@ func IsExist(path string) bool {
 	return err == nil || os.IsExist(err)
 }
 
+func IsDir(path string) bool {
+	s, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return s.IsDir()
+}
+
 // 获取测试数据
 func GetParseTestData(line string, size int) []string {
 	testSlice := make([]string, 0)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -248,6 +248,14 @@ func TestCheckErr(t *testing.T) {
 	}
 }
 
+func TestIsDir(t *testing.T) {
+	dir := "meta_test_is_dir"
+	createDirWithName(dir)
+	defer os.RemoveAll(dir)
+	isDir := IsDir(dir)
+	assert.Equal(t, true, isDir)
+}
+
 func createDirWithName(dirx string) {
 	if err := os.Mkdir(dirx, DefaultDirPerm); err != nil {
 		log.Error(err)


### PR DESCRIPTION
## Fixes 

## logkit s3 和 cloudtrail 元数据目录生成逻辑不依赖ak/sk

   
- [ ] feature1
- [ ] feature2
- [ ] fixbug1
- [ ] fixbug2
 
## Reviewers

- [ ] @[someone] please review
- [ ] @[someotherone] please review

## Wiki Changes
 
- options1...
- options2...
    
## Checklist
   
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Wiki updated
