### PR TITLE
KeyValue转换器切分方式修改

### DIFF
--- a/parser/logfmt/logfmt.go
+++ b/parser/logfmt/logfmt.go
@@ -1,21 +1,14 @@
 package logfmt
 
 import (
-	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 	"sync"
-	"unicode"
 
 	"github.com/qiniu/logkit/conf"
 	"github.com/qiniu/logkit/parser"
 	. "github.com/qiniu/logkit/parser/config"
 	. "github.com/qiniu/logkit/utils/models"
-)
-
-const (
-	errMsg = "will keep origin data in pandora_stash if disable_record_errdata field is false"
+	"github.com/qiniu/logkit/utils/parse/mutate"
 )
 
 func init() {
@@ -53,8 +46,12 @@ func NewParser(c conf.MapConf) (parser.Parser, error) {
 }
 
 func (p *Parser) Parse(lines []string) ([]Data, error) {
-	if p.splitter == "" {
-		p.splitter = "="
+	mp := mutate.Parser{
+		KeepString: p.keepString,
+		Splitter:   p.splitter,
+	}
+	if mp.Splitter == "" {
+		mp.Splitter = "="
 	}
 	var (
 		lineLen = len(lines)
@@ -73,7 +70,7 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 
 	for i := 0; i < numRoutine; i++ {
 		wg.Add(1)
-		go parser.ParseLineDataSlice(sendChan, resultChan, wg, true, p.parse)
+		go parser.ParseLineDataSlice(sendChan, resultChan, wg, true, mp.Parse)
 	}
 
 	go func() {
@@ -144,118 +141,6 @@ func (p *Parser) Parse(lines []string) ([]Data, error) {
 		return datas, nil
 	}
 	return datas, se
-}
-
-func (p *Parser) parse(line string) ([]Data, error) {
-
-	pairs, err := splitKV(line, p.splitter)
-	if err != nil {
-		return nil, err
-	}
-
-	// 调整数据类型
-	if len(pairs)%2 == 1 {
-		return nil, errors.New(fmt.Sprintf("key value not match, %s", errMsg))
-	}
-
-	data := make([]Data, 0, 1)
-	field := make(Data)
-	for i := 0; i < len(pairs); i += 2 {
-		// 消除双引号； 针对foo="" ,"foo=" 情况；其他情况如 a"b"c=d"e"f等首尾不出现引号的情况视作合法。
-		kNum := strings.Count(pairs[i], "\"")
-		vNum := strings.Count(pairs[i+1], "\"")
-		if kNum%2 == 1 && vNum%2 == 1 {
-			if strings.HasPrefix(pairs[i], "\"") && strings.HasSuffix(pairs[i+1], "\"") {
-				pairs[i] = pairs[i][1:]
-				pairs[i+1] = pairs[i+1][:len(pairs[i+1])-1]
-			}
-		}
-		if kNum%2 == 0 && len(pairs[i]) > 1 {
-			if strings.HasPrefix(pairs[i], "\"") && strings.HasSuffix(pairs[i], "\"") {
-				pairs[i] = pairs[i][1 : len(pairs[i])-1]
-			}
-		}
-		if vNum%2 == 0 && len(pairs[i+1]) > 1 {
-			if strings.HasPrefix(pairs[i+1], "\"") && strings.HasSuffix(pairs[i+1], "\"") {
-				pairs[i+1] = pairs[i+1][1 : len(pairs[i+1])-1]
-			}
-		}
-
-		if len(pairs[i]) == 0 || len(pairs[i+1]) == 0 {
-			return nil, fmt.Errorf("no value or key was parsed after logfmt, %s", errMsg)
-		}
-
-		value := pairs[i+1]
-		if !p.keepString {
-			if fValue, err := strconv.ParseFloat(value, 64); err == nil {
-				field[pairs[i]] = fValue
-				continue
-			}
-			if bValue, err := strconv.ParseBool(value); err == nil {
-				field[pairs[i]] = bValue
-				continue
-			}
-
-		}
-		field[pairs[i]] = value
-	}
-	if len(field) == 0 {
-		return nil, fmt.Errorf("data is empty after parse, %s", errMsg)
-	}
-
-	data = append(data, field)
-	return data, nil
-}
-
-func splitKV(line string, sep string) ([]string, error) {
-	data := make([]string, 0, 100)
-
-	if !strings.Contains(line, sep) {
-		return nil, errors.New(fmt.Sprintf("no splitter exist, %s", errMsg))
-	}
-
-	kvArr := make([]string, 0, 100)
-	isKey := true
-	vhead := 0
-	lastSpace := 0
-	pos := 0
-	sepLen := len(sep)
-
-	// key或value值中包含sep的情况；默认key中不包含sep；导致algorithm = 1+1=2会变成合法
-	for pos+sepLen <= len(line) {
-		if unicode.IsSpace(rune(line[pos : pos+1][0])) {
-			nextSep := strings.Index(line[pos+1:], sep)
-			if nextSep == -1 {
-				break
-			}
-			if strings.TrimSpace(line[pos+1:pos+1+nextSep]) != "" {
-				lastSpace = pos
-				pos++
-				continue
-			}
-		}
-		if line[pos:pos+sepLen] == sep {
-			if isKey {
-				kvArr = append(kvArr, strings.TrimSpace(line[vhead:pos]))
-				isKey = false
-			} else {
-				if lastSpace <= vhead {
-					pos++
-					continue
-				}
-				kvArr = append(kvArr, strings.TrimSpace(line[vhead:lastSpace]))
-				kvArr = append(kvArr, strings.TrimSpace(line[lastSpace:pos]))
-			}
-			vhead = pos + sepLen
-			pos = pos + sepLen - 1
-		}
-		pos++
-	}
-	if vhead < len(line) {
-		kvArr = append(kvArr, strings.TrimSpace(line[vhead:]))
-	}
-	data = append(data, kvArr...)
-	return data, nil
 }
 
 func (p *Parser) Name() string {

--- a/parser/logfmt/logfmt_test.go
+++ b/parser/logfmt/logfmt_test.go
@@ -1,14 +1,12 @@
 package logfmt
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/qiniu/logkit/parser"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/qiniu/logkit/conf"
+	"github.com/qiniu/logkit/parser"
 	. "github.com/qiniu/logkit/parser/config"
 	"github.com/qiniu/logkit/utils"
 	. "github.com/qiniu/logkit/utils/models"
@@ -31,120 +29,6 @@ func Benchmark_ParseLine(b *testing.B) {
 		m, _ = p.Parse(testData)
 	}
 	bench = m
-}
-
-func Test_parseLine(t *testing.T) {
-	tests := []struct {
-		line       string
-		keepString bool
-		expectData []Data
-		existErr   bool
-		splitter   string
-	}{
-		{
-			expectData: []Data{},
-			existErr:   true,
-			splitter:   "=",
-		},
-		{
-			line: "foo=\"bar\"",
-			expectData: []Data{
-				{"foo": "bar"},
-			},
-			splitter: "=",
-		},
-		{
-			line: "foo=\"bar\"\n",
-			expectData: []Data{
-				{"foo": "bar"},
-			},
-			splitter: "=",
-		},
-		{
-			line: "ts=2018-01-02T03:04:05.123Z lvl=info msg=\"http request\" method=PUT\nduration=1.23 log_id=123456abc",
-			expectData: []Data{
-				{
-					"lvl":      "info",
-					"msg":      "http request",
-					"method":   "PUT",
-					"duration": 1.23,
-					"ts":       "2018-01-02T03:04:05.123Z",
-					"log_id":   "123456abc",
-				},
-			},
-			splitter: "=",
-		},
-		{
-			line: `ts=2018-01-02T03:04:05.123Z lvl=info  method=PUT msg="http request" a=12345678901234567890123456789`,
-			expectData: []Data{
-				{
-					"lvl":    "info",
-					"msg":    "http request",
-					"method": "PUT",
-					"ts":     "2018-01-02T03:04:05.123Z",
-					"a":      1.2345678901234568e+28,
-				},
-			},
-			splitter: "=",
-		},
-		{
-			line:       `ts=2018-01-02T03:04:05.123Z lvl=info  method=PUT msg="http request" a=12345678901234567890123456789`,
-			keepString: true,
-			expectData: []Data{
-				{
-					"lvl":    "info",
-					"msg":    "http request",
-					"method": "PUT",
-					"ts":     "2018-01-02T03:04:05.123Z",
-					"a":      "12345678901234567890123456789",
-				},
-			},
-			splitter: "=",
-		},
-		{
-			line:       `no data.`,
-			expectData: []Data{},
-			existErr:   true,
-			splitter:   "=",
-		},
-		{
-			line:       `foo="" bar=`,
-			expectData: []Data{},
-			existErr:   true,
-			splitter:   "=",
-		},
-		{
-			line: `abc=abc foo="def`,
-			expectData: []Data{
-				{
-					"abc": "abc",
-					"foo": "\"def",
-				},
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line:       `"foo=" bar=abc`,
-			expectData: []Data{},
-			existErr:   true,
-			splitter:   "=",
-		},
-	}
-	l := Parser{
-		name: TypeLogfmt,
-	}
-	for _, tt := range tests {
-		l.keepString = tt.keepString
-		l.splitter = tt.splitter
-		got, err := l.parse(tt.line)
-		fmt.Println("got: ", got, " err: ", err)
-		assert.Equal(t, tt.existErr, err != nil)
-		assert.Equal(t, len(tt.expectData), len(got))
-		for i, m := range got {
-			assert.Equal(t, tt.expectData[i], m)
-		}
-	}
 }
 
 func TestParse(t *testing.T) {
@@ -295,7 +179,7 @@ func TestParseWithKeepRawData(t *testing.T) {
 					"lvl":      float64(5),
 					"msg":      "error",
 					"log_id":   "123456abc",
-					"method":"PUT",
+					"method":   "PUT",
 					"duration": 1.23,
 					"raw_data": "ts:2018-01-02T03:04:05.123Z lvl:5 msg:\"error\" log_id:123456abc\nmethod:PUT duration:1.23 log_id:123456abc",
 				},
@@ -331,156 +215,5 @@ func GetParseTestData(line string, size int) []string {
 		}
 		testSlice = append(testSlice, line)
 		totalSize += len(line)
-	}
-}
-
-func Test_splitKV(t *testing.T) {
-
-	tests := []struct {
-		line       string
-		expectData []string
-		existErr   bool
-		splitter   string
-	}{
-		{
-			line: "foo=",
-			expectData: []string{
-				"foo",
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "=def",
-			expectData: []string{
-				"",
-				"def",
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "foo=def abc = abc ",
-			expectData: []string{
-				"foo",
-				"def",
-				"abc",
-				"abc",
-
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "foo\n=def\nabc=a\nbc",
-			expectData: []string{
-				"foo",
-				"def",
-				"abc",
-				"a\nbc",
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "foo=def \n abc =abc",
-			expectData: []string{
-				"foo",
-				"def",
-				"abc",
-				"abc",
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "foo=def\n abc=abc",
-			expectData: []string{
-				"foo",
-				"def",
-				"abc",
-				"abc",
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "foo=def\n test abc=abc",
-			expectData: []string{
-				"foo",
-				"def\n test",
-				"abc",
-				"abc",
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "time=2018-01-02T03:04:05.123Z \nCST abc=abc",
-			expectData: []string{
-				"time",
-				"2018-01-02T03:04:05.123Z \nCST",
-				"abc",
-				"abc",
-			},
-			existErr: false,
-			splitter: "=",
-		},
-		{
-			line: "foo:de:f ad abc:a:b:c",
-			expectData: []string{
-				"foo",
-				"de:f ad",
-				"abc",
-				"a:b:c",
-			},
-			existErr: false,
-			splitter: ":",
-		},
-		{
-			line: "f:o:o::def",
-			expectData: []string{
-				"f:o:o",
-				"def",
-			},
-			existErr: false,
-			splitter: "::",
-		},
-		{
-			line:       "f:o:o:def",
-			expectData: []string{},
-			existErr:   true,
-			splitter:   "::",
-		},
-		{
-			line:       "f:o:o:\n:def",
-			expectData: nil,
-			existErr:   true,
-			splitter:   "::",
-		},
-		{
-			line: "f:\no::a o:\n:def",
-			expectData: []string{
-				"f:\no",
-				"a o:\n:def",
-			},
-			existErr: false,
-			splitter: "::",
-		},
-		{
-			line:       "f:o:o: \n :def",
-			expectData: []string{},
-			existErr:   true,
-			splitter:   "::",
-		},
-	}
-	for _, tt := range tests {
-		got, err := splitKV(tt.line, tt.splitter)
-		assert.Equal(t, tt.existErr, err != nil)
-		assert.Equal(t, len(tt.expectData), len(got))
-		for i, m := range got {
-			assert.Equal(t, tt.expectData[i], m)
-		}
-
 	}
 }

--- a/parser/syslog/syslog_test.go
+++ b/parser/syslog/syslog_test.go
@@ -144,7 +144,7 @@ func TestSyslogParser_TimeZone(t *testing.T) {
 	assert.Nil(t, err)
 	lines := []string{
 		`<1>Feb 05 01:02:03 abc system[253]: Listening at 0.0.0.0:3000`,
-		`<34>1 2019-02-04T17:02:03.000Z mymachine.example.com su - ID47`,
+		`<34>1 2020-02-04T17:02:03.000Z mymachine.example.com su - ID47`,
 	}
 	dts, err := p.Parse(lines)
 	assert.Nil(t, err)
@@ -152,6 +152,6 @@ func TestSyslogParser_TimeZone(t *testing.T) {
 	assert.Nil(t, err)
 	dts = append(dts, ndata...)
 	for _, dt := range dts {
-		assert.Equal(t, "2019-02-04 17:02:03 +0000 UTC", dt["timestamp"].(time.Time).String())
+		assert.Equal(t, "2020-02-04 17:02:03 +0000 UTC", dt["timestamp"].(time.Time).String())
 	}
 }

--- a/transforms/mutate/keyvalue_test.go
+++ b/transforms/mutate/keyvalue_test.go
@@ -2,6 +2,7 @@ package mutate
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,7 @@ func TestKV_Transform(t *testing.T) {
 		{
 			line:       []Data{{"raw": `123456789012345`}},
 			expectData: []Data{{"raw": `123456789012345`}},
-			expectErr:  errors.New("find total 1 erorrs in transform keyvalue, last error info is no value matched in key value transform in raw"),
+			expectErr:  errors.New("find total 1 erorrs in transform keyvalue, last error info is parse transform key value failed, error msg: no splitter exist, will keep origin data in pandora_stash if disable_record_errdata field is false"),
 			splitter:   "=",
 			keepString: true,
 			new:        "raw",
@@ -93,21 +94,21 @@ func TestKV_Transform(t *testing.T) {
 		{
 			line:       []Data{{"raw": `foo="" bar=`}},
 			expectData: []Data{{"raw": `foo="" bar=`}},
-			expectErr:  errors.New("find total 1 erorrs in transform keyvalue, last error info is no value matched in key value transform in raw"),
+			expectErr:  errors.New("find total 1 erorrs in transform keyvalue, last error info is parse transform key value failed, error msg: key value not match, will keep origin data in pandora_stash if disable_record_errdata field is false"),
 			splitter:   "=",
 			new:        "raw",
 		},
 		{
 			line:       []Data{{"raw": `abc=abc foo="def`}},
-			expectData: []Data{{"raw": `abc=abc foo="def`}},
-			expectErr:  errors.New("find total 1 erorrs in transform keyvalue, last error info is logfmt syntax error at pos 17 on line 1: unterminated quoted value"),
+			expectData: []Data{{"raw": Data{"abc": "abc", "foo": "\"def"}}},
+			expectErr:  nil,
 			splitter:   "=",
 			new:        "raw",
 		},
 		{
 			line:       []Data{{"raw": `"foo=" bar=abc`}},
 			expectData: []Data{{"raw": `"foo=" bar=abc`}},
-			expectErr:  errors.New(`find total 1 erorrs in transform keyvalue, last error info is logfmt syntax error at pos 1 on line 1: unexpected '"'`),
+			expectErr:  errors.New(`find total 1 erorrs in transform keyvalue, last error info is parse transform key value failed, error msg: no value or key was parsed after logfmt, will keep origin data in pandora_stash if disable_record_errdata field is false`),
 			splitter:   "=",
 			new:        "raw",
 		},
@@ -153,4 +154,156 @@ func TestKV_Transform(t *testing.T) {
 	assert.Nil(t, err)
 	expect := []Data{{"foo": "bar"}}
 	assert.EqualValues(t, expect, res)
+
+	k = &KV{
+		Key:        "test.Old",
+		New:        "test.New",
+		DiscardKey: true,
+		Splitter:   "=",
+	}
+	assert.Nil(t, k.Init())
+	line = []Data{{"test": Data{"Old": "foo=\"bar\"\n"}}}
+	res, err = k.Transform(line)
+	assert.Nil(t, err)
+	expect = []Data{{"test": Data{"New": Data{"foo": "bar"}}}}
+	assert.EqualValues(t, expect, res)
+}
+
+func Test_kvTransform(t *testing.T) {
+	type args struct {
+		strVal     string
+		splitter   string
+		keepString bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Data
+		wantErr bool
+	}{
+		{
+			name: "empty_test",
+			args: args{
+				strVal:     "",
+				splitter:   "=",
+				keepString: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "normal_test",
+			args: args{
+				strVal:     "foo=\"bar\"",
+				splitter:   "=",
+				keepString: true,
+			},
+			want:    Data{"foo": "bar"},
+			wantErr: false,
+		},
+		{
+			name: "normal_test_2",
+			args: args{
+				strVal: "ts=2018-01-02T03:04:05.123Z  lvl=info msg=\"http request\" 	method=PUT\nduration=1.23 log_id=123456abc",
+				splitter:   "=",
+				keepString: false,
+			},
+			want: Data{
+				"ts":       "2018-01-02T03:04:05.123Z",
+				"lvl":      "info",
+				"msg":      "http request",
+				"method":   "PUT",
+				"duration": 1.23,
+				"log_id":   "123456abc",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty_test",
+			args: args{
+				strVal:     "123456789012345",
+				splitter:   "=",
+				keepString: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "err_test_1",
+			args: args{
+				strVal:     "a:12345678901234567890123456789",
+				splitter:   "=",
+				keepString: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "err_test_2",
+			args: args{
+				strVal:     `foo="" bar="`,
+				splitter:   "=",
+				keepString: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "err_test_3",
+			args: args{
+				strVal:     `abc=abc foo="def`,
+				splitter:   "=",
+				keepString: true,
+			},
+			want: Data{
+				"abc": "abc",
+				"foo": "\"def",
+			},
+			wantErr: false,
+		},
+		{
+			name: "err_test_4",
+			args: args{
+				strVal:     `"foo=" bar=abc`,
+				splitter:   "=",
+				keepString: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "err_test_5",
+			args: args{
+				strVal:     "ts:2018-01-02T03:04:05.123Z lvl:info msg:\"http request\" method:PUT\nduration:1.23 log_id:123456abc",
+				splitter:   "=",
+				keepString: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "err_test_6",
+			args: args{
+				strVal:     `foo="bar"`,
+				splitter:   "=",
+				keepString: true,
+			},
+			want: Data{
+				"foo": "bar",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := kvTransform(tt.args.strVal, tt.args.splitter, tt.args.keepString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("kvTransform() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("kvTransform() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/utils/parse/mutate/keyvalue.go
+++ b/utils/parse/mutate/keyvalue.go
@@ -1,0 +1,132 @@
+package mutate
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/qiniu/logkit/utils/models"
+)
+
+const (
+	errMsg = "will keep origin data in pandora_stash if disable_record_errdata field is false"
+)
+
+type Parser struct {
+	KeepString bool
+	Splitter   string
+}
+
+func (p *Parser) Parse(line string) ([]models.Data, error) {
+
+	pairs, err := splitKV(line, p.Splitter)
+	if err != nil {
+		return nil, err
+	}
+
+	// 调整数据类型
+	if len(pairs)%2 == 1 {
+		return nil, errors.New(fmt.Sprintf("key value not match, %s", errMsg))
+	}
+
+	data := make([]models.Data, 0, 1)
+	field := make(models.Data)
+	for i := 0; i < len(pairs); i += 2 {
+		// 消除双引号； 针对foo="" ,"foo=" 情况；其他情况如 a"b"c=d"e"f等首尾不出现引号的情况视作合法。
+		kNum := strings.Count(pairs[i], "\"")
+		vNum := strings.Count(pairs[i+1], "\"")
+		if kNum%2 == 1 && vNum%2 == 1 {
+			if strings.HasPrefix(pairs[i], "\"") && strings.HasSuffix(pairs[i+1], "\"") {
+				pairs[i] = pairs[i][1:]
+				pairs[i+1] = pairs[i+1][:len(pairs[i+1])-1]
+			}
+		}
+		if kNum%2 == 0 && len(pairs[i]) > 1 {
+			if strings.HasPrefix(pairs[i], "\"") && strings.HasSuffix(pairs[i], "\"") {
+				pairs[i] = pairs[i][1 : len(pairs[i])-1]
+			}
+		}
+		if vNum%2 == 0 && len(pairs[i+1]) > 1 {
+			if strings.HasPrefix(pairs[i+1], "\"") && strings.HasSuffix(pairs[i+1], "\"") {
+				pairs[i+1] = pairs[i+1][1 : len(pairs[i+1])-1]
+			}
+		}
+
+		if len(pairs[i]) == 0 || len(pairs[i+1]) == 0 {
+			return nil, fmt.Errorf("no value or key was parsed after logfmt, %s", errMsg)
+		}
+
+		value := pairs[i+1]
+		if !p.KeepString {
+			if fValue, err := strconv.ParseFloat(value, 64); err == nil {
+				field[pairs[i]] = fValue
+				continue
+			}
+			if bValue, err := strconv.ParseBool(value); err == nil {
+				field[pairs[i]] = bValue
+				continue
+			}
+
+		}
+		field[pairs[i]] = value
+	}
+	if len(field) == 0 {
+		return nil, fmt.Errorf("data is empty after parse, %s", errMsg)
+	}
+
+	data = append(data, field)
+	return data, nil
+}
+
+func splitKV(line string, sep string) ([]string, error) {
+	data := make([]string, 0, 100)
+
+	if !strings.Contains(line, sep) {
+		return nil, errors.New(fmt.Sprintf("no splitter exist, %s", errMsg))
+	}
+
+	kvArr := make([]string, 0, 100)
+	isKey := true
+	vhead := 0
+	lastSpace := 0
+	pos := 0
+	sepLen := len(sep)
+
+	// key或value值中包含sep的情况；默认key中不包含sep；导致algorithm = 1+1=2会变成合法
+	for pos+sepLen <= len(line) {
+		if unicode.IsSpace(rune(line[pos : pos+1][0])) {
+			nextSep := strings.Index(line[pos+1:], sep)
+			if nextSep == -1 {
+				break
+			}
+			if strings.TrimSpace(line[pos+1:pos+1+nextSep]) != "" {
+				lastSpace = pos
+				pos++
+				continue
+			}
+		}
+		if line[pos:pos+sepLen] == sep {
+			if isKey {
+				kvArr = append(kvArr, strings.TrimSpace(line[vhead:pos]))
+				isKey = false
+			} else {
+				if lastSpace <= vhead {
+					pos++
+					continue
+				}
+				kvArr = append(kvArr, strings.TrimSpace(line[vhead:lastSpace]))
+				kvArr = append(kvArr, strings.TrimSpace(line[lastSpace:pos]))
+			}
+			vhead = pos + sepLen
+			pos = pos + sepLen - 1
+		}
+		pos++
+	}
+	if vhead < len(line) {
+		kvArr = append(kvArr, strings.TrimSpace(line[vhead:]))
+	}
+	data = append(data, kvArr...)
+	return data, nil
+}

--- a/utils/parse/mutate/keyvalue_test.go
+++ b/utils/parse/mutate/keyvalue_test.go
@@ -1,0 +1,275 @@
+package mutate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qiniu/logkit/utils/models"
+)
+
+func Test_parseLine(t *testing.T) {
+	tests := []struct {
+		line       string
+		keepString bool
+		expectData []models.Data
+		existErr   bool
+		splitter   string
+	}{
+		{
+			expectData: []models.Data{},
+			existErr:   true,
+			splitter:   "=",
+		},
+		{
+			line: "foo=\"bar\"",
+			expectData: []models.Data{
+				{"foo": "bar"},
+			},
+			splitter: "=",
+		},
+		{
+			line: "foo=\"bar\"\n",
+			expectData: []models.Data{
+				{"foo": "bar"},
+			},
+			splitter: "=",
+		},
+		{
+			line: "ts=2018-01-02T03:04:05.123Z lvl=info msg=\"http request\" method=PUT\nduration=1.23 log_id=123456abc",
+			expectData: []models.Data{
+				{
+					"lvl":      "info",
+					"msg":      "http request",
+					"method":   "PUT",
+					"duration": 1.23,
+					"ts":       "2018-01-02T03:04:05.123Z",
+					"log_id":   "123456abc",
+				},
+			},
+			splitter: "=",
+		},
+		{
+			line: `ts=2018-01-02T03:04:05.123Z lvl=info  method=PUT msg="http request" a=12345678901234567890123456789`,
+			expectData: []models.Data{
+				{
+					"lvl":    "info",
+					"msg":    "http request",
+					"method": "PUT",
+					"ts":     "2018-01-02T03:04:05.123Z",
+					"a":      1.2345678901234568e+28,
+				},
+			},
+			splitter: "=",
+		},
+		{
+			line:       `ts=2018-01-02T03:04:05.123Z lvl=info  method=PUT msg="http request" a=12345678901234567890123456789`,
+			keepString: true,
+			expectData: []models.Data{
+				{
+					"lvl":    "info",
+					"msg":    "http request",
+					"method": "PUT",
+					"ts":     "2018-01-02T03:04:05.123Z",
+					"a":      "12345678901234567890123456789",
+				},
+			},
+			splitter: "=",
+		},
+		{
+			line:       `no data.`,
+			expectData: []models.Data{},
+			existErr:   true,
+			splitter:   "=",
+		},
+		{
+			line:       `foo="" bar=`,
+			expectData: []models.Data{},
+			existErr:   true,
+			splitter:   "=",
+		},
+		{
+			line: `abc=abc foo="def`,
+			expectData: []models.Data{
+				{
+					"abc": "abc",
+					"foo": "\"def",
+				},
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line:       `"foo=" bar=abc`,
+			expectData: []models.Data{},
+			existErr:   true,
+			splitter:   "=",
+		},
+	}
+	l := Parser{
+		KeepString: false,
+		Splitter:   "",
+	}
+	for _, tt := range tests {
+		l.KeepString = tt.keepString
+		l.Splitter = tt.splitter
+		got, err := l.Parse(tt.line)
+		fmt.Println("got: ", got, " err: ", err)
+		assert.Equal(t, tt.existErr, err != nil)
+		assert.Equal(t, len(tt.expectData), len(got))
+		for i, m := range got {
+			assert.Equal(t, tt.expectData[i], m)
+		}
+	}
+}
+
+func Test_splitKV(t *testing.T) {
+
+	tests := []struct {
+		line       string
+		expectData []string
+		existErr   bool
+		splitter   string
+	}{
+		{
+			line: "foo=",
+			expectData: []string{
+				"foo",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "=def",
+			expectData: []string{
+				"",
+				"def",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "foo=def abc = abc ",
+			expectData: []string{
+				"foo",
+				"def",
+				"abc",
+				"abc",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "foo\n=def\nabc=a\nbc",
+			expectData: []string{
+				"foo",
+				"def",
+				"abc",
+				"a\nbc",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "foo=def \n abc =abc",
+			expectData: []string{
+				"foo",
+				"def",
+				"abc",
+				"abc",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "foo=def\n abc=abc",
+			expectData: []string{
+				"foo",
+				"def",
+				"abc",
+				"abc",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "foo=def\n test abc=abc",
+			expectData: []string{
+				"foo",
+				"def\n test",
+				"abc",
+				"abc",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "time=2018-01-02T03:04:05.123Z \nCST abc=abc",
+			expectData: []string{
+				"time",
+				"2018-01-02T03:04:05.123Z \nCST",
+				"abc",
+				"abc",
+			},
+			existErr: false,
+			splitter: "=",
+		},
+		{
+			line: "foo:de:f ad abc:a:b:c",
+			expectData: []string{
+				"foo",
+				"de:f ad",
+				"abc",
+				"a:b:c",
+			},
+			existErr: false,
+			splitter: ":",
+		},
+		{
+			line: "f:o:o::def",
+			expectData: []string{
+				"f:o:o",
+				"def",
+			},
+			existErr: false,
+			splitter: "::",
+		},
+		{
+			line:       "f:o:o:def",
+			expectData: []string{},
+			existErr:   true,
+			splitter:   "::",
+		},
+		{
+			line:       "f:o:o:\n:def",
+			expectData: nil,
+			existErr:   true,
+			splitter:   "::",
+		},
+		{
+			line: "f:\no::a o:\n:def",
+			expectData: []string{
+				"f:\no",
+				"a o:\n:def",
+			},
+			existErr: false,
+			splitter: "::",
+		},
+		{
+			line:       "f:o:o: \n :def",
+			expectData: []string{},
+			existErr:   true,
+			splitter:   "::",
+		},
+	}
+	for _, tt := range tests {
+		got, err := splitKV(tt.line, tt.splitter)
+		assert.Equal(t, tt.existErr, err != nil)
+		assert.Equal(t, len(tt.expectData), len(got))
+		for i, m := range got {
+			assert.Equal(t, tt.expectData[i], m)
+		}
+
+	}
+}


### PR DESCRIPTION
将原先的有logfmt包切分，复用为parse模块里的keyvalue切分方式