### PR TITLE
mongo支持导出全量数据

### DIFF
--- a/reader/config/config.go
+++ b/reader/config/config.go
@@ -980,7 +980,7 @@ var ModeKeyOptions = map[string][]Option{
 			KeyName:      KeyMongoOffsetKey,
 			ChooseOnly:   false,
 			Default:      "_id",
-			Required:     true,
+			Required:     false,
 			DefaultNoUse: false,
 			Description:  "递增的主键(mongo_offset_key)",
 			ToolTip:      `指定一个mongo的列名，作为offset的记录，类型必须是整型(比如unixnano的时间，或者自增的primary key)`,

--- a/reader/mongo/mongo.go
+++ b/reader/mongo/mongo.go
@@ -37,6 +37,7 @@ type CollectionFilter map[string]interface{}
 
 const (
 	DefaultOffsetKey = "_id"
+	EmptyOffsetKey   = ""
 )
 
 const (
@@ -95,7 +96,7 @@ func NewReader(meta *reader.Meta, conf conf.MapConf) (reader.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	offsetkey, _ := conf.GetStringOr(KeyMongoOffsetKey, DefaultOffsetKey)
+	offsetkey, _ := conf.GetStringOr(KeyMongoOffsetKey, EmptyOffsetKey)
 	cronSched, _ := conf.GetStringOr(KeyMongoCron, "")
 	execOnStart, _ := conf.GetBoolOr(KeyMongoExecOnstart, true)
 	filters, _ := conf.GetStringOr(KeyMongoFilters, "")
@@ -361,6 +362,10 @@ func (r *Reader) catQuery(c string, lastID interface{}, mgoSession *mgo.Session)
 	query := bson.M{}
 	if f, ok := r.collectionFilters[c]; ok {
 		query = bson.M(f)
+	}
+
+	if r.offsetkey == EmptyOffsetKey {
+		return mgoSession.DB(r.database).C(c).Find(query)
 	}
 	if lastID != nil {
 		query[r.offsetkey] = bson.M{"$gt": lastID}


### PR DESCRIPTION
## Fixes [issue number]

## mongo 递增主键改为可填，为空时，导出全量数据，不排序。
   
- [ ] feature1
- [ ] feature2
- [ ] fixbug1
- [ ] fixbug2
 
## Reviewers

- [ ] @[someone] please review
- [ ] @[someotherone] please review

## Wiki Changes
 
- options1...
- options2...
    
## Checklist
   
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Wiki updated
