### PR TITLE
[PDR-12106][feat(reader)]执行脚本超时时间只有5秒，不可调整，脚本执行较慢时无法使用，任务被程序直接kill

### DIFF
--- a/reader/config/config.go
+++ b/reader/config/config.go
@@ -1363,6 +1363,16 @@ var ModeKeyOptions = map[string][]Option{
 			ToolTip:      `定时任务触发周期，直接写"loop"循环执行，crontab的写法，类似于* * * * * *，对应的是秒(0~59)，分(0~59)，时(0~23)，日(1~31)，月(1-12)，星期(0~6)，填*号表示所有遍历都执行`,
 		},
 		{
+			KeyName:      KeyScriptTimeout,
+			ChooseOnly:   false,
+			Default:      "5s",
+			Placeholder:  "5s",
+			DefaultNoUse: false,
+			Description:  "超时时间(script_timeout)",
+			Advance:      true,
+			ToolTip:      `脚本的执行超时时间，超过这个时间，脚本会被强制停止执行`,
+		},
+		{
 			KeyName:       KeyScriptExecOnStart,
 			Element:       Radio,
 			ChooseOnly:    true,

--- a/reader/config/models.go
+++ b/reader/config/models.go
@@ -124,6 +124,7 @@ const (
 
 	KeyScriptParams        = "script_params"
 	KeyScriptParamsSpliter = "script_params_spliter"
+	KeyScriptTimeout      = "script_timeout"
 	KeyScriptContent       = "script_content"
 	KeyExecInterpreter     = "script_exec_interprepter"
 	KeyScriptCron          = "script_cron"

--- a/reader/script/script_test.go
+++ b/reader/script/script_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -102,15 +103,15 @@ func Test_ScriptWithParams(t *testing.T) {
 }
 
 func TestCmdRunWithTimeout(t *testing.T) {
-	cmdResult, isTimeout := CmdRunWithTimeout("echo", "hello")
+	cmdResult, isTimeout := CmdRunWithTimeout("echo", 5*time.Second, "hello")
 	assert.Nil(t, cmdResult.err)
 	assert.False(t, isTimeout)
 	assert.EqualValues(t, "hello\n", string(cmdResult.content))
 
-	cmdResult, isTimeout = CmdRunWithTimeout("test")
+	cmdResult, isTimeout = CmdRunWithTimeout("test", 5*time.Second)
 	assert.NotNil(t, cmdResult.err)
 	assert.False(t, isTimeout)
 
-	cmdResult, _ = CmdRunWithTimeout("top")
+	cmdResult, _ = CmdRunWithTimeout("top", 5*time.Second)
 	assert.NotNil(t, cmdResult.err)
 }


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
- [ ] feature1
- [ ] feature2
- [ ] fixbug1
- [ ] fixbug2
 
## Reviewers

- [ ] @[someone] please review
- [ ] @[someotherone] please review

## Wiki Changes
 
- options1...
- options2...
    
## Checklist
   
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Wiki updated
