### PR TITLE
[PDR-12988][fix(ci)]修复ci data race

### DIFF
--- a/mgr/dataflow_test.go
+++ b/mgr/dataflow_test.go
@@ -135,8 +135,7 @@ func Test_RawDataWithReadData(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	RawDataTimeOut = 30 * time.Second
+	runnerConf.ReaderConfig[readerconf.KeyRawDataTimeout] = "30"
 	rawData, err := RawData(runnerConf.ReaderConfig)
 	if err != nil {
 		t.Error(err)
@@ -144,7 +143,6 @@ func Test_RawDataWithReadData(t *testing.T) {
 
 	expected := []string{"{\n  \"logkit\": \"logkit\"\n}"}
 	assert.Equal(t, expected, rawData)
-	RawDataTimeOut = 30 * time.Second
 }
 
 func Test_RawData_DaemonReader(t *testing.T) {
@@ -681,11 +679,11 @@ func Test_RawData_MultiLines(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"abc\n", "abc\n"}, actual)
 
-	RawDataTimeOut = 3 * time.Second
+	readConfig[readerconf.KeyRawDataTimeout] = "3"
 	os.RemoveAll(fileName)
 	createRawDataFile(fileName, "abc\n")
 	actual, err = RawData(readConfig)
-	RawDataTimeOut = 30 * time.Second
+	readConfig[readerconf.KeyRawDataTimeout] = "30"
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"abc\n"}, actual)
 }

--- a/mgr/metric_runner_test.go
+++ b/mgr/metric_runner_test.go
@@ -200,8 +200,8 @@ func metricRunTest(p *testParam) {
 	base := filepath.Base("")
 	metaPath := "meta/" + runnerName + "_" + Hash(base)
 	t.Log("metaPath: ", metaPath)
-	for i := 0; !utils.IsExist(metaPath) && i < 6; i++ {
-		time.Sleep(500 * time.Millisecond)
+	for i := 0; !utils.IsExist(metaPath) && i < 20; i++ {
+		time.Sleep(1 * time.Second)
 		i++
 	}
 	assert.True(t, utils.IsExist(metaPath))

--- a/reader/config/models.go
+++ b/reader/config/models.go
@@ -10,6 +10,7 @@ const (
 	KeyAuthUsername = "auth_username"
 	KeyAuthPassword = "auth_password"
 
+	KeyRawDataTimeout    = "raw_data_timeout"
 	KeyLogPath           = "log_path"
 	KeyLogPathOld        = "log_path_old"
 	KeyMetaPath          = "meta_path"

--- a/sender/fault_tolerant/fault_tolerant_test.go
+++ b/sender/fault_tolerant/fault_tolerant_test.go
@@ -9,11 +9,10 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/qiniu/pandora-go-sdk/base/reqerr"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/qiniu/log"
+	"github.com/qiniu/pandora-go-sdk/base/reqerr"
 	"github.com/qiniu/pandora-go-sdk/pipeline"
 
 	"github.com/qiniu/logkit/conf"

--- a/utils/parse/mutate/keyvalue_test.go
+++ b/utils/parse/mutate/keyvalue_test.go
@@ -167,9 +167,10 @@ func Test_parseLine(t *testing.T) {
 		},
 		{
 			line: "fo o=def  = abc ",
-			expectData: []string{
-				"fo o",
-				"def  = abc",
+			expectData: []models.Data{
+				{
+					"fo o": "def  = abc",
+				},
 			},
 			existErr: false,
 			splitter: "=",


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
Data Race不是每次CI跑单测的时候都会提示错误，所以有几点没有注意到
1. RawDataTimeOut是全局变量，不能直接修改，所以改成可传递参数，增加默认值，不影响使用
2. tailx sendError会有channel data race问题，通过加锁或者select来避免往closed channel发数据
 
## Reviewers

- [ ] @redHJ 
