### PR TITLE
Skip check if redis_datatype is channel

### DIFF
--- a/reader/redis/redis.go
+++ b/reader/redis/redis.go
@@ -101,7 +101,7 @@ func NewReader(meta *reader.Meta, conf conf.MapConf) (reader.Reader, error) {
 
 	for _, val := range opt.key {
 		keyType, _ := client.Type(val).Result()
-		if dataType != keyType {
+		if keyType != "none" && dataType != keyType {
 			return nil, fmt.Errorf("key[%v]'s type expect as %v,actual get %v", val, dataType, keyType)
 		}
 	}


### PR DESCRIPTION
## Fixes [issue number]

[#1149](https://github.com/qiniu/logkit/issues/1149)

## Changes
   
- [x] Fixed redis reader crash issue if redis_datatype is channel
- [x] Fixed redis reader crash issue if Redis server is empty
 
