### PR TITLE
[PDR-14621][fix(cleaner)]cleaner停止后无法继续启动

### DIFF
--- a/cleaner/cleaner.go
+++ b/cleaner/cleaner.go
@@ -94,17 +94,13 @@ func NewCleaner(conf conf.MapConf, meta *reader.Meta, cleanChan chan<- CleanSign
 		cleanChan:     cleanChan,
 		name:          name,
 		logdir:        logdir,
-		status:        config.StatusInit,
+		status:        config.StatusStopped,
 	}, nil
 }
 
 func (c *Cleaner) Run() {
-	if !atomic.CompareAndSwapInt32(&c.status, config.StatusInit, config.StatusRunning) {
-		if c.hasStopped() {
-			log.Warnf("cleaner[%v] has stopped, run operation ignored", c.name)
-		} else {
-			log.Warnf("cleaner[%v] has already running, run operation ignored", c.name)
-		}
+	if !atomic.CompareAndSwapInt32(&c.status, config.StatusStopped, config.StatusRunning) {
+		log.Warnf("cleaner[%v] has already running, run operation ignored", c.name)
 		return
 	}
 	for {
@@ -186,7 +182,7 @@ func (c *Cleaner) Clean() (err error) {
 		}
 	}()
 	if c.hasStopped() {
-		log.Warnf("cleaner[%v] reader %s has stopped, skip clean operation", c.name)
+		log.Warnf("cleaner[%v] has stopped, skip clean operation", c.name)
 		return
 	}
 	var size int64 = 0

--- a/cleaner/cleaner_test.go
+++ b/cleaner/cleaner_test.go
@@ -144,10 +144,7 @@ func Test_clean(t *testing.T) {
 	}
 	defer os.RemoveAll(donefiles)
 	cl.reserveNumber = 1
-	err = cl.Clean()
-	if err != nil {
-		t.Error(err)
-	}
+	go cl.Run()
 	time.Sleep(2 * time.Second)
 	files, err := ioutil.ReadDir(donefiles)
 	if err != nil {
@@ -162,6 +159,7 @@ func Test_clean(t *testing.T) {
 	if !reflect.DeepEqual(gots, exps) {
 		t.Fatalf("test clean error exps %v got %v", exps, gots)
 	}
+	cl.Close()
 	err = os.RemoveAll(donefiles)
 	if err != nil {
 		t.Error(err)
@@ -171,10 +169,7 @@ func Test_clean(t *testing.T) {
 		t.Fatal(err)
 	}
 	cl.reserveSize = 9 * MB
-	err = cl.Clean()
-	if err != nil {
-		t.Error(err)
-	}
+	go cl.Run()
 	time.Sleep(2 * time.Second)
 	files, err = ioutil.ReadDir(donefiles)
 	if err != nil {
@@ -196,6 +191,7 @@ func Test_clean(t *testing.T) {
 	if string(sd) != expstr {
 		t.Errorf("exps %v got %v", expstr, string(sd))
 	}
+	cl.Close()
 	err = os.RemoveAll(donefiles)
 	if err != nil {
 		t.Error(err)
@@ -205,12 +201,12 @@ func Test_clean(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	time.Sleep(1 * time.Second)
 	cl.reserveNumber = 10
 	cl.reserveSize = 10 * 1024 * 1024
-	err = cl.Clean()
-	if err != nil {
-		t.Error(err)
-	}
+	go cl.Run()
+	defer cl.Close()
 	time.Sleep(2 * time.Second)
 	files, err = ioutil.ReadDir(donefiles)
 	if err != nil {


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
- [ ] cleaner停止后，状态改为stopped，再次启动时会直接退出
 
## Reviewers

- [ ] @redHJ 

## Wiki Changes
 
- options1...
- options2...
    
## Checklist
   
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Wiki updated
