### PR TITLE
[PDR-15311][fix(mssql)]: MSSQL数据库,当遇到数值型字段为空的时候采集会报错

### DIFF
--- a/reader/sql/utils.go
+++ b/reader/sql/utils.go
@@ -152,6 +152,11 @@ func GetInitScans(length int, rows *sql.Rows, schemas map[string]string, runnerN
 				nochoiced[i] = true
 			}
 		}
+		nullable, ok := v.Nullable()
+		nullable = nullable && ok
+		if nullable {
+			scanArgs[i] = new(interface{})
+		}
 	}
 	return scanArgs, nochoiced
 }


### PR DESCRIPTION
## Fixes [issue number]

## Changes
   
- [ ] mssql驱动github.com/denisenkom/go-mssqldb中 获取数据库列类型的方法 MssqlRows::ColumnTypeScanType，该方法不会考虑字段为空的情形，只会返回基本类型，导致解析数据时抛出类似nil无法赋值给float64的错误。解决办法：对于nullable=true的字段，通过interface{}类型接收。
 
## Reviewers

- [ ] @[someone] please review
- [ ] @[someotherone] please review

## Wiki Changes
 
- options1...
- options2...
    
## Checklist
   
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Wiki updated
