### PR TITLE
[PDR-16094][fix(lag)]: dirx/dir模式下lag显示不正确

### DIFF
--- a/reader/dirx/dir_reader.go
+++ b/reader/dirx/dir_reader.go
@@ -465,6 +465,18 @@ func (drs *dirReaders) SyncMeta() ([]byte, error) {
 	return data, nil
 }
 
+func (drs *dirReaders) Lag() (rl *LagInfo, err error) {
+	rl = &LagInfo{Size: 0, SizeUnit: "bytes"}
+	for _, dr := range drs.getReaders() {
+		drLag, err := dr.br.Lag()
+		if err != nil {
+			return nil, err
+		}
+		rl.Size += drLag.Size
+	}
+	return rl, nil
+}
+
 func (drs *dirReaders) Close() {
 	var wg sync.WaitGroup
 	for _, dr := range drs.getReaders() {

--- a/reader/dirx/dirx.go
+++ b/reader/dirx/dirx.go
@@ -422,6 +422,10 @@ func (r *Reader) ReadLine() (string, error) {
 	}
 }
 
+func (r *Reader) Lag() (rl *LagInfo, err error) {
+	return r.dirReaders.Lag()
+}
+
 func (r *Reader) Status() StatsInfo {
 	r.statsLock.RLock()
 	defer r.statsLock.RUnlock()


### PR DESCRIPTION
## Fixes [issue number]

## 问题
   
- [ ] dir模式一直显示有待读取内容
- [ ] dirx模式不显示lag

## 问题定位
dir采集显示待读取逻辑：

old：对目录下所有文件按修改时间排序，从最新的文件开始遍历，如果不是当前在读文件，则认为是未读文件，lag会加上该文件的大小，如果是当前文件，则加上 当前文件大小 - 当前读取位置offset，遇到当前文件后退出循环，认为后续文件都是已读文件。

该逻辑在windows下是有问题的，因为windows下文件的更新时间不是及时的，即文件内容有追加后，修改时间可能是不改变的，过一段时间或者flush后，才会变动。 

## Reviewers

- [ ] @[someone] please review
- [ ] @[someotherone] please review

## Wiki Changes
 
- options1...
- options2...
    
## Checklist
   
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Wiki updated
